### PR TITLE
Using simple ASCII instead of Unicode for Windows

### DIFF
--- a/src/done.js
+++ b/src/done.js
@@ -1,12 +1,21 @@
 'use strict';
 
+var osType = require('os').type().toLowerCase();
+
 /**
  * @description outputs our error messages when compvare (or a thumbs up if no errors)
  * @return void
  */
 module.exports = function done( app, kill ) {
 	var i = 0,
-		len = app.warnings.length;
+		len = app.warnings.length,
+		emojiAllClear = '\uD83D\uDC4D ',
+		emojiWarning = '\uD83D\uDCA9 ';
+
+	if ( osType.indexOf('windows') >= 0 ) {
+		emojiAllClear = ':)';
+		emojiWarning = ':(';
+	}
 
 	// output error messages
 	for ( i; i < len; i++ ) {
@@ -15,13 +24,13 @@ module.exports = function done( app, kill ) {
 
 	// if you set a max it displays a slightly more annoying message (that'll show em!)
 	if ( app.config.maxWarnings && len > app.config.maxWarnings ) {
-		console.log( '\uD83D\uDCA9 ', 'Stylint: ' + len + ' warnings. Max is set to: ' + app.config.maxWarnings );
+		console.log( emojiWarning, 'Stylint: ' + len + ' warnings. Max is set to: ' + app.config.maxWarnings );
 	}
 	else if ( len === 0 ) {
-		console.log( '\uD83D\uDC4D ', 'Stylint: You\'re all clear!' );
+		console.log( emojiAllClear, 'Stylint: You\'re all clear!' );
 	}
 	else {
-		console.log( '\n\uD83D\uDCA9 ', len + ' Warnings' );
+		console.log( '\n' + emojiWarning, len + ' Warnings' );
 	}
 
 	// if we got here via an error


### PR DESCRIPTION
Windows consoles can't render the cool Unicode emoji in the "all clear"
and "warning" logs, so we will instead render simple ASCII.

Works around #55.