### PR TITLE
Add ability to use absolute config path

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 var
 	stampit = require('stampit'),
 	fs = require('fs'),
-	pathSeparator = require('path').sep,
+	pathIsAbsolute = require('path-is-absolute'),
 	glob = require('glob').Glob,
 	done = require('./src/done'),
 	help = require('./src/help'),
@@ -156,7 +156,7 @@ var coreMethods = stampit().methods({
 		});
 	},
 	setConfig: function( path ) {
-		path = path.charAt(0) === pathSeparator ? path : process.cwd() + '/' + path;
+		path = pathIsAbsolute( path ) ? path : process.cwd() + '/' + path;
 		return JSON.parse( fs.readFileSync( path ) );
 	},
 	done: done,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
 var
 	stampit = require('stampit'),
 	fs = require('fs'),
+	pathSeparator = require('path').sep,
 	glob = require('glob').Glob,
 	done = require('./src/done'),
 	help = require('./src/help'),
@@ -155,7 +156,8 @@ var coreMethods = stampit().methods({
 		});
 	},
 	setConfig: function( path ) {
-		return JSON.parse( fs.readFileSync( process.cwd() + '/' + path ) );
+		path = path.charAt(0) === pathSeparator ? path : process.cwd() + '/' + path;
+		return JSON.parse( fs.readFileSync( path ) );
 	},
 	done: done,
 	help: help,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "chokidar": "0.12.3",
     "glob": "4.3.1",
+    "path-is-absolute": "1.0.0",
     "stampit": "1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Hi, Absolutely loving this linter!

## Description
I've come across the need to have an absolute path for my config file, which doesn't currently work as the `process.cwd()` gets automatically prepended to the config path.

**Ideal usage:** `stylint foo.styl -c /Users/jack/.stylintrc`

## Solution
This pull request adds a check to see if the specified config path is absolute. If it is, it uses it exactly as supplied. If it's not, it continues to use the code you had in place already.

In future, it might be nice to use node's [path.isAbsolute()](https://nodejs.org/api/path.html#path_path_isabsolute_path), but as it was only just released with node 0.12, I went with something more backwards compatible.

## Tests
I've not added a test for this, as your existing config tests have an outstanding `@TODO` comment. Wasn't sure whether you'd like to own that, or if you want me to give it a go. The existing tests still pass as expected.

## Justification
I'm putting together a SublimeLinter Stylint plugin which allows for 'live' linting. Like jshint, it traverses up the directory tree to find a config file, then supplies its absolute path to Stylint. Early days, but happy to collaborate once I've progressed a little further if you'd like.

![sublime-stylint](https://cloud.githubusercontent.com/assets/720908/6710579/a703d200-cd79-11e4-86ee-a9fc50e43e23.gif)
