### PR TITLE
Improve sortOrder warnings

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -93,7 +93,9 @@ module.exports = function test( app, line, num, output, file ) {
 				}
 
 				if ( app.sortOrder(line, valid, app.config.sortOrder) === false ) {
-					cache.warnings.push( 'preferred sort order is ' + app.config.sortOrder + '\nFile: ' + file + '\nLine: ' + num + ': ' + output );
+					var preferredSortOrder = Array.isArray(app.config.sortOrder) ? '{Array}' : app.config.sortOrder;
+
+					cache.warnings.push( 'preferred sort order is ' + preferredSortOrder + '\nFile: ' + file + '\nLine: ' + num + ': ' + output );
 				}
 			}
 


### PR DESCRIPTION
Sorry, my bad, but just realised that https://github.com/rossPatton/stylint/blob/master/src/test.js#L96 is going to be one heck of a warning message when users are using a custom defined Array