### PR TITLE
Updated name of option

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Example if true: the following will throw a warning
 ```
 
 
-### indentSpaces ( default: 4, number or false )
+### indentPref ( default: 4, number or false )
 This works in conjunction with depthLimit. If you indent with spaces this is the number of spaces you indent with. If you use hard tabs, set this value to false.
 
 By default this value is false, so if you indent with spaces you'll need to manually set this value in a custom `.stylintrc` file.


### PR DESCRIPTION
It looks like `indentSpaces` should be `indentPref`, this commit updates the name.
`indentSpaces` is probably a leftover from the olden days.