### PR TITLE
Ignore id selectors in colors check

### DIFF
--- a/src/checks/colors.js
+++ b/src/checks/colors.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var hexRe = /#(?:[0-9a-f]{3}){1,2}/im
+var ignoreRe = /^\s*(?:#|.*=.*)/
 
 
 /**
@@ -9,7 +10,7 @@ var hexRe = /#(?:[0-9a-f]{3}){1,2}/im
  * @returns {boolean} true if hex color found, false if not
  */
 var colors = function( line ) {
-	if ( line.indexOf( '=' ) !== -1 ) { return }
+	if ( ignoreRe.test( line ) ) { return }
 	var hex = false
 
 	// so basically if we're using #hex colors outside of a var declaration

--- a/test/test.js
+++ b/test/test.js
@@ -682,12 +682,16 @@ describe('Linter Style Checks: ', function() {
 			app.state.conf = true
 		})
 
+		it('undefined if line is an id selector', function () {
+			assert.equal( undefined, colorsTest('#aaa') )
+		})
+
 		it('false if a line doesnt have a hex color', function () {
-			assert.equal( false, colorsTest('.foo') )
+			assert.equal( false, colorsTest('color: red') )
 		})
 
 		it('true if line has hex color', function () {
-			assert.equal( true, colorsTest('#fff') )
+			assert.equal( true, colorsTest('color: #fff') )
 		})
 
 		it('undefined if hex color is being assigned to a variable', function () {


### PR DESCRIPTION
Currently, any id selector with the first 3 consecutive letters in `[a-f]` will fail the colors check. This PR adds an ignore regex that checks for an id selector (or variable assignment) before linting.