### PR TITLE
Allow vendor-prefixed @keyframes

### DIFF
--- a/src/state/keyframesStart.js
+++ b/src/state/keyframesStart.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var keyframeRe = /@(?:-(?:[\w\d]+-)*)?keyframes/
 
 /**
  * @description check for keyframes, which have some special rules
@@ -9,7 +10,7 @@
 var keyframesStart = function( line ) {
 	if ( this.state.keyframes ) { return }
 
-	if ( line.indexOf( '@keyframe' ) !== -1 ) {
+	if ( keyframeRe.test( line ) ) {
 		this.state.keyframes = true
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -316,7 +316,7 @@ describe('Core Methods: ', function() {
 		})
 
 		it('return undefined if keyframes starting', function() {
-			assert.equal( undefined, app.setState( '@keyframe' ) )
+			assert.equal( undefined, app.setState( '@keyframes' ) )
 		})
 
 		it('keyframes should be set to true now', function() {
@@ -1202,6 +1202,11 @@ describe('Linter Style Checks: ', function() {
 		it('true if line has @keyframes', function() {
 			app.state.keyframes = false
 			assert.equal( true, keyframesStartTest('@keyframes {') )
+		})
+
+		it('true if line has vendor @keyframes', function() {
+			app.state.keyframes = false
+			assert.equal( true, keyframesStartTest('@-webkit-keyframes {') )
 		})
 
 		it('false if line isnt a start of @keyframes', function() {


### PR DESCRIPTION
Also updates to only look for `@keyframes` plural, since `@keyframe` should be considered invalid.