### PR TITLE
Only print individual error-message if they exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 coverage
 lcov.info
 wired-styl
+.idea/

--- a/src/core/done.js
+++ b/src/core/done.js
@@ -16,16 +16,13 @@ var done = function() {
 
 	// when testing we want to silence the console a bit, so we have the quiet option
 	if ( !this.state.quiet ) {
-		this.cache.errs.forEach( function( err ) {
-			return warningsOrErrors.push( err )
-		} )
+		warningsOrErrors = [].concat( this.cache.errs, this.cache.warnings ).filter( function ( str ) { return !!str } )
 
-		this.cache.warnings.forEach( function( war ) {
-			return warningsOrErrors.push( war )
-		} )
+		if ( warningsOrErrors.length ) {
+			msg = warningsOrErrors.join( '\n\n' ) + '\n'
+		}
 
-		msg = warningsOrErrors.join( '\n\n' )
-		msg += '\n' + this.cache.msg
+		msg += this.cache.msg
 		console.log( msg )
 	}
 


### PR DESCRIPTION
I'm currently writing a reporter, but I want to print out per error, not sorted into errors and warnings. Returning blank before the end creates lots of extra whitespace. 

This change only prints out per violation-warnings if they exist.

Difference in my reporter is 
![image](https://cloud.githubusercontent.com/assets/1404810/8762070/3b41a452-2d6e-11e5-8b4f-81b16e540523.png)

vs.

![image](https://cloud.githubusercontent.com/assets/1404810/8762072/52614b24-2d6e-11e5-9d63-cd8151ae5eeb.png)

Regarding tests: Do you have any tests on output to the console? I didn't see any, that's why I haven't written one for this change.

(Link to reporter: https://github.com/SimenB/stylint-stylish)
