### PR TITLE
Read current version from package.json

### DIFF
--- a/src/core/ver.js
+++ b/src/core/ver.js
@@ -1,8 +1,10 @@
 'use strict'
 
+var pkg = require( '../../package.json' )
+
 // called when --version or -v flags used, just displays version number
 var ver = function() {
-	return console.log( '\nStylint version: 1.0.8\n' )
+	return console.log( '\nStylint version: ' + pkg.version + '\n' )
 }
 
 module.exports = ver


### PR DESCRIPTION
Noticed you change it in the source on each version-bump. This reads it out instead.