### PR TITLE
Lint a string

### DIFF
--- a/bin/stylint
+++ b/bin/stylint
@@ -33,8 +33,13 @@ var options = yargs
 	.epilogue( 'GPL-3.0 License' )
 	.argv
 
-stylint().create( {}, {
+var stylintInstance = stylint().create( {}, {
 	watch: options.watch,
 	config: options.config,
 	strict: options.strict
 }, options._[0] )
+
+// to allow instantiation without doing anything, manually call read
+if ( !options.watch ) {
+	stylintInstance.read()
+}

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var stampit = require( 'stampit' )
 // basic app flow below
 // init() -> read() -> parse() -> lint() -> done()
 // init() -> watch() -> read() -> parse() -> lint() -> done()
-var Stylint = function( path, config ) {
+var stylint = function( path, config ) {
 	var Lint
 
 	Lint = stampit().compose(
@@ -26,4 +26,9 @@ var Stylint = function( path, config ) {
 	return Lint
 }
 
-module.exports = Stylint
+var api = function( config ) {
+	return stylint().create( {}, { config: config } )
+}
+
+module.exports = stylint
+module.exports.api = api

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chokidar": "1.0.1",
     "glob": "4.3.1",
     "lodash.defaults": "3.1.2",
+    "lodash.groupby": "3.1.1",
     "path-is-absolute": "1.0.0",
     "stampit": "1.1.0",
     "strip-json-comments": "1.0.2",

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -4,7 +4,6 @@ var path = require( 'path' )
 var cache = {
 	allViolations: [], // an array containing every warning or error
 	comment: '', // the current line comment on the line, if there is one
-	errs: [], // array of errors detected so far
 	file: '', // curr filename we're testing
 	files: [], // all files as an arr
 	filesLen: 0, // # of files we're testing
@@ -21,7 +20,6 @@ var cache = {
 	dir: path.dirname( require.main.filename ), // index.js directory
 	sCache: { '0': [] }, // each key is an array of selectors in that context
 	sortOrderCache: [], // we keep a context based arr of selectors here to check sort orde
-	warnings: [], // array of the errors detected so far
 	zCache: [] // array of z-index uses
 }
 

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -2,6 +2,7 @@ var path = require( 'path' )
 
 // the main cache bject
 var cache = {
+	allViolations: [], // an array containing every warning or error
 	comment: '', // the current line comment on the line, if there is one
 	errs: [], // array of errors detected so far
 	file: '', // curr filename we're testing
@@ -16,6 +17,7 @@ var cache = {
 	prevFile: '', // the previous file
 	prevFileNo: 0, // prev file no
 	prevLine: '', // the previous line
+	reporterCache: {}, // a cache for use by the reporter
 	dir: path.dirname( require.main.filename ), // index.js directory
 	sCache: { '0': [] }, // each key is an array of selectors in that context
 	sortOrderCache: [], // we keep a context based arr of selectors here to check sort orde

--- a/src/core/done.js
+++ b/src/core/done.js
@@ -1,5 +1,14 @@
 'use strict'
 
+var groupBy = require( 'lodash.groupby' )
+
+function shouldKill( warningsOrErrors ) {
+	var maxErrs = typeof this.config.maxErrors === 'number' ? this.config.maxErrors : false
+	var maxWarnings = typeof this.config.maxWarnings === 'number' ? this.config.maxWarnings : false
+
+	return maxErrs && warningsOrErrors.Error && warningsOrErrors.Error.length > this.config.maxErrors ||
+		maxWarnings && warningsOrErrors.Warning && warningsOrErrors.Warning.length > this.config.maxWarnings
+}
 /**
  * @description outputs our messages, wipes errs/warnings if watching
  * @returns {Object | Function} returns process exit if not watching, or obj otherwise
@@ -8,22 +17,42 @@ var done = function() {
 	var warningsOrErrors = []
 	var msg = ''
 
+	var errors = this.cache.allViolations.filter( function( e ) {
+		return e.severity === 'Error'
+	} )
+
 	// if no errors, give clean exit code
-	if ( this.cache.errs.length > 0 ) {
+	if ( errors.length > 0 ) {
 		this.state.exitCode = 1
 	}
 
 	// when testing we want to silence the console a bit, so we have the quiet option
 	if ( !this.state.quiet ) {
-		warningsOrErrors = [].concat( this.cache.errs, this.cache.warnings ).filter( function( str ) { return !!str } )
+		this.cache.allViolations.forEach( function( violation ) {
+			this.reporter( violation )
+		}.bind( this ) )
+
+		warningsOrErrors = groupBy( this.cache.allViolations, 'severity' )
+
+		this.reporter( null, 'done', shouldKill.call( this, warningsOrErrors ) ? 'kill' : null )
+
+		warningsOrErrors = []
+			.concat( warningsOrErrors.Error, warningsOrErrors.Warning )
+			.map( function( violation ) {
+				return violation.message
+			} )
+			.filter( function( message ) {
+				return !!message
+			} )
 
 		if ( warningsOrErrors.length ) {
 			msg = warningsOrErrors.join( '\n\n' ) + '\n'
 		}
 
 		msg += '\n' + this.cache.msg
+		msg = msg.trim()
 
-		if ( msg.trim() ) {
+		if ( msg ) {
 			console.log( msg )
 		}
 	}
@@ -35,16 +64,12 @@ var done = function() {
 	}
 
 	var returnValue = {
-		errs: this.cache.errs.slice( 0 ),
-		warnings: this.cache.warnings.slice( 0 ),
 		allViolations: this.cache.allViolations.slice( 0 ),
 		exitCode: this.state.exitCode,
 		msg: this.cache.msg
 	}
 
 	// if watching we reset the errors/warnings arrays
-	this.cache.errs = []
-	this.cache.warnings = []
 	this.cache.allViolations = []
 
 	return returnValue

--- a/src/core/done.js
+++ b/src/core/done.js
@@ -37,6 +37,7 @@ var done = function() {
 	var returnValue = {
 		errs: this.cache.errs.slice( 0 ),
 		warnings: this.cache.warnings.slice( 0 ),
+		allViolations: this.cache.allViolations.slice( 0 ),
 		exitCode: this.state.exitCode,
 		msg: this.cache.msg
 	}
@@ -44,6 +45,7 @@ var done = function() {
 	// if watching we reset the errors/warnings arrays
 	this.cache.errs = []
 	this.cache.warnings = []
+	this.cache.allViolations = []
 
 	return returnValue
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -11,6 +11,7 @@ var core = stampit().methods( {
 	parse: require( './parse' ),
 	setState: require( './setState' ),
 	lint: require( './lint' ),
+	lintText: require( './lintText' ),
 	watch: require( './watch' ),
 
 	// utilities below

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -47,7 +47,7 @@ var init = function( options, pathPassed ) {
 		return this.watch()
 	}
 
-	return this.read()
+	return this
 }
 
 module.exports = init

--- a/src/core/lint.js
+++ b/src/core/lint.js
@@ -7,8 +7,6 @@
 var lint = function() {
 	var method = ''
 	var checks = Object.getPrototypeOf( this ).lintMethods
-	var maxErrs = typeof this.config.maxErrors === 'number' ? this.config.maxErrors : false
-	var maxWarnings = typeof this.config.maxWarnings === 'number' ? this.config.maxWarnings : false
 
 	for ( method in checks ) {
 		if ( checks.hasOwnProperty( method ) ) {
@@ -19,15 +17,6 @@ var lint = function() {
 				this.state.severity = this.config[method].error ? 'Error' : 'Warning'
 				// run the actual check against the line
 				checks[method].call( this, this.cache.line )
-				// if check puts us over either limit, kill stylint
-				if ( maxErrs &&
-					this.cache.errs.length > this.config.maxErrors ) {
-					return this.reporter( '', 'done', 'kill' )
-				}
-				if ( maxWarnings &&
-					this.cache.warnings.length > this.config.maxWarnings ) {
-					return this.reporter( '', 'done', 'kill' )
-				}
 			}
 		}
 	}

--- a/src/core/lintText.js
+++ b/src/core/lintText.js
@@ -1,0 +1,35 @@
+'use strict'
+
+/**
+ * @description wrapper for parse for programmatic use
+ * @param {String} string the text to parse
+ * @param {Object} [config] an object containing config to lint by
+ * @param {String} [filename] the name of the file
+ * @returns {Array} an array of all violations in the given string
+ */
+var lintText = function( string, config, filename ) {
+	// reset stuff
+	this.resetOnChange()
+
+	if ( config ) {
+		this.init( { config: config } )
+	}
+
+	// make sure there is no output to the console
+	this.state.quiet = true
+
+	// don't kill process
+	this.state.watching = true
+
+	// never kill the linter
+	this.config.maxErrors = null
+	this.config.maxWarnings = null
+
+	this.cache.file = filename
+
+	this.parse( null, [string] )
+
+	return this.cache.allViolations.slice( 0 ) // return a copy of all violations
+}
+
+module.exports = lintText

--- a/src/core/lintText.js
+++ b/src/core/lintText.js
@@ -1,11 +1,13 @@
 'use strict'
 
+var groupBy = require( 'lodash.groupby' )
+
 /**
  * @description wrapper for parse for programmatic use
  * @param {String} string the text to parse
  * @param {Object} [config] an object containing config to lint by
  * @param {String} [filename] the name of the file
- * @returns {Array} an array of all violations in the given string
+ * @returns {Object} an object containing an array of all violations and total number of warnings/errors in the given string
  */
 var lintText = function( string, config, filename ) {
 	// reset stuff
@@ -25,11 +27,18 @@ var lintText = function( string, config, filename ) {
 	this.config.maxErrors = null
 	this.config.maxWarnings = null
 
-	this.cache.file = filename
+	this.cache.files = [filename]
 
-	this.parse( null, [string] )
+	this.parse( null, [string], true )
 
-	return this.cache.allViolations.slice( 0 ) // return a copy of all violations
+	var results = this.cache.allViolations.slice( 0 ) // a copy of all violations
+	var warningsOrErrors = groupBy( results, 'severity' )
+
+	return {
+		results: results,
+		numOfErrors: warningsOrErrors.Error ? warningsOrErrors.Error.length : 0,
+		numOfWarnings: warningsOrErrors.Warning ? warningsOrErrors.Warning.length : 0
+	}
 }
 
 module.exports = lintText

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -9,9 +9,10 @@ var lineEndingsRe = /\r\n|\n|\r/gm
  * @description parses file for testing by removing extra new lines and block comments
  * @param {Object} [err] error obj from async if it exists
  * @param {Array} [res] array of files to parse
+ * @param {boolean} [skipDone] if true, don't call done
  * @returns {Function} test function
  */
-var parse = function( err, res ) {
+var parse = function( err, res, skipDone ) {
 	if ( err ) { throw new Error( err ) }
 
 	return res.forEach( function( file, i ) {
@@ -39,8 +40,8 @@ var parse = function( err, res ) {
 		this.cache.prevFile = this.cache.file
 
 		// if on the last file, call the done function to output success or error msg
-		if ( this.cache.fileNo === res.length - 1 ) {
-			return this.reporter( '', 'done' )
+		if ( this.cache.fileNo === res.length - 1 && !skipDone ) {
+			return this.done()
 		}
 	}.bind( this ) )
 }

--- a/src/core/reporter.js
+++ b/src/core/reporter.js
@@ -1,34 +1,41 @@
 'use strict'
 
+var groupBy = require( 'lodash.groupby' )
+
 /**
  * format output message for console
- * @param  {string}   msg  error msg from one of the checks
+ * @param  {object}   msg  error msg from one of the checks
  * @param  {string}   done whether or not this is the last message to output
  * @param  {string}   kill whether or not we're over one of our limits
- * @return {string | Function} either the formatted msg or done()
+ * @return {string | undefined} either the formatted msg or nothing
  */
 var reporter = function( msg, done, kill ) {
 	if ( done === 'done' ) {
-		// total errors
-		this.cache.msg = '\nStylint: ' + this.cache.errs.length + ' Errors.'
+		this.cache.msg = ''
+
+		if ( this.cache.allViolations.length === 0 && kill !== 'kill' ) {
+			return
+		}
+
+		var violations = groupBy( this.cache.allViolations, 'severity' )
+		var numOfErrors = violations.Error ? violations.Error.length : 0
+		var numOfWarnings = violations.Warning ? violations.Warning.length : 0
+
+		this.cache.msg += '\nStylint: ' + numOfErrors + ' Errors.'
 		this.cache.msg += this.config.maxErrors ? ' (Max Errors: ' + this.config.maxErrors + ')' : ''
-		// total warnings
-		this.cache.msg += '\nStylint: ' + this.cache.warnings.length + ' Warnings.'
+
+		this.cache.msg += '\nStylint: ' + numOfWarnings + ' Warnings.'
 		this.cache.msg += this.config.maxWarnings ? ' (Max Warnings: ' + this.config.maxWarnings + ')' : ''
 
 		// if you set a max it kills the linter
 		if ( kill === 'kill' ) {
 			this.cache.msg += '\nStylint: Over Error or Warning Limit.'
 		}
-		else if ( this.cache.errs.length === 0 &&
-			this.cache.warnings.length === 0 ) {
-			this.cache.msg = ''
-		}
 
-		return this.done()
+		return
 	}
 
-	return this.state.severity + ': ' + msg + '\nFile: ' + this.cache.file + '\nLine: ' + this.cache.lineNo + ': ' + this.cache.origLine.trim()
+	return msg.severity + ': ' + msg.message + '\nFile: ' + msg.file + '\nLine: ' + msg.lineNo + ': ' + msg.origLine.trim()
 }
 
 module.exports = reporter

--- a/src/utils/msg.js
+++ b/src/utils/msg.js
@@ -11,6 +11,14 @@ var msg = function( str ) {
 	// determine which group the msg belongs to
 	arr = this.state.severity === 'Warning' ? this.cache.warnings : this.cache.errs
 
+	this.cache.allViolations.push( {
+		message: str,
+		severity: this.state.severity,
+		file: this.cache.file,
+		lineNo: this.cache.lineNo,
+		origLine: this.cache.origLine
+	} )
+
 	// push the final output
 	return arr.push( this.reporter( str ) )
 }

--- a/src/utils/msg.js
+++ b/src/utils/msg.js
@@ -1,26 +1,18 @@
 'use strict'
 
 /**
- * @description basically just sets the severity and routes output to the reporter
+ * @description add violation to an array
  * @param {string} [str] outputted string from one of the checks
- * @returns {Function} push formatted output to appropriate array
+ * @returns {Array} push formatted output to appropriate array
 */
 var msg = function( str ) {
-	var arr
-
-	// determine which group the msg belongs to
-	arr = this.state.severity === 'Warning' ? this.cache.warnings : this.cache.errs
-
-	this.cache.allViolations.push( {
+	return this.cache.allViolations.push( {
 		message: str,
 		severity: this.state.severity,
 		file: this.cache.file,
 		lineNo: this.cache.lineNo,
 		origLine: this.cache.origLine
 	} )
-
-	// push the final output
-	return arr.push( this.reporter( str ) )
 }
 
 module.exports = msg

--- a/src/utils/resetOnChange.js
+++ b/src/utils/resetOnChange.js
@@ -8,8 +8,6 @@
 var resetOnChange = function( newPath ) {
 	this.state.path = newPath ? newPath : this.state.path
 	this.cache.allViolations = []
-	this.cache.errs = []
-	this.cache.warnings = []
 	this.cache.alphaCache = []
 	this.cache.selectorCache = []
 	this.cache.rootCache = []

--- a/src/utils/resetOnChange.js
+++ b/src/utils/resetOnChange.js
@@ -7,6 +7,7 @@
 */
 var resetOnChange = function( newPath ) {
 	this.state.path = newPath ? newPath : this.state.path
+	this.cache.allViolations = []
 	this.cache.errs = []
 	this.cache.warnings = []
 	this.cache.alphaCache = []
@@ -16,6 +17,7 @@ var resetOnChange = function( newPath ) {
 	this.cache.prevLine = ''
 	this.cache.prevFile = ''
 	this.cache.prevContext = 0
+	this.cache.reporterCache = {}
 
 	if ( this.state.watching ) {
 		return this.read()

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,8 @@ var chokidar = require( 'chokidar' )
 var touch = require( 'touch' )
 require( 'chai' ).should()
 var sinon = require( 'sinon' )
-var app = require( '../index' )().create()
+var stylint = require( '../index' )
+var app = stylint().create()
 var stripJsonComments = require( 'strip-json-comments' )
 
 // turn on strict mode from this point and turn off unecessary logging
@@ -2354,4 +2355,18 @@ describe( 'Done, again: ', function() {
 	// 	app.done.getCall(0).returned( sinon.match.same( process.exit ) )
 	// 	app.state.watching = true
 	// } )
+} )
+
+describe( 'Lint Text: ', function() {
+	var linter
+
+	beforeEach(function() {
+		linter = stylint.api()
+	} )
+
+	it( 'should return object with violations', function() {
+		var lintText = app.lintText( '.class {\n  color: red !important\n}\n' )
+
+		assert.equal(lintText.length, 4)
+	} )
 } )


### PR DESCRIPTION
:warning: Not ready for merge

A small start to being able to lint strings. Fixes #146 & #160

How to call it is a bit undecided, but for now it's
```js
var stylint = require('stylint')

stylint.api(optionalConfig).lintText(stringWithStylus, optionalConfig, optionalFilename)
```

Returned from that is an array containing all violations.
Sample using default options: 
```js
import {api} from 'stylint'
const stylintInstance = api()
// ... Some time later
stylintInstance.lintText('.class {\n  color: red !important\n}\n', null, 'filename.styl')
```
returns
```js
[ { message: 'unecessary bracket',
    severity: 'Warning',
    file: 'filename.styl',
    lineNo: 1,
    origLine: '.class {' },
  { message: '!important is disallowed ',
    severity: 'Warning',
    file: 'filename.styl',
    lineNo: 2,
    origLine: '  color: red !important' },
  { message: 'missing semicolon',
    severity: 'Warning',
    file: 'filename.styl',
    lineNo: 2,
    origLine: '  color: red !important' },
  { message: 'unecessary bracket',
    severity: 'Warning',
    file: 'filename.styl',
    lineNo: 3,
    origLine: '}' } ]
```

Currently working on restructuring how reporters are called. Moving the logic for it to `done`, so that done calls reporters and not the other way around