### PR TITLE
Add stylint-loader info

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ grunt.initConfig({
 });
 ```
 
+## Webpack
+You can use [stylint-loader](https://github.com/guerrero/stylint-loader)
+
+```javascript
+module.exports = {
+  // ...
+  module: {
+    preLoaders: [
+      {
+        test: /\.styl$/, 
+        loader: 'stylint'
+      }
+    ],
+    loaders: [
+      {
+        test: /\.styl$/,
+        loader: 'style!css!stylus'
+      }
+    ]
+  }
+  // ...
+}
+```
+
 
 ## As Part of Your Workflow
 Stylint integrations with both Sublime Text 3 and Atom.io are available.


### PR DESCRIPTION
I've recently switched from sass to stylus and stylint has been rather helpful. The main problem is that I'm also using webpack and is a bit tedious to run each tool separately so I've created a stylint loader for webpack (webpack loaders are similar to gulp or grunt plugins).

I want to share it with the community because maybe it can be helpful for someone else so it would be nice to add a reference in this repo README.

Thanks!