### PR TITLE
Fix #168

### DIFF
--- a/src/checks/namingConvention.js
+++ b/src/checks/namingConvention.js
@@ -3,9 +3,9 @@
 // the alphabet, uppers
 var upperRe = /[A-Z]+/m
 // BEM (http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/)
-var bemRe = /^([$.#{:][${a-z]([-]?[${}a-z0-9]+)*(_{2}[${}a-z0-9]([-]?[${}a-z0-9]+)*)?((_[${}a-z0-9]([-]?[a-z0-9}]+)*){2})*)\b/m
+var bemRe = /([$.#{:][${a-z]([-]?[${}a-z0-9]+)*(_{2}[${}a-z0-9]([-]?[${}a-z0-9]+)*)?((_[${}a-z0-9]([-]?[a-z0-9}]+)*){2})*)\b/m
 // camelCase or CamelCase
-var camelRe = /^[$#.{:]+([a-zA-Z]|[${}])+([a-z]|[${}])+(([.A-Z0-9])+[a-z ]+)+\b/m
+var camelRe = /[$#.{:]+([a-zA-Z]|[${}])+([a-z]|[${}])+(([.A-Z0-9])+[a-z ]+)+\b/m
 
 
 /**
@@ -15,53 +15,52 @@ var camelRe = /^[$#.{:]+([a-zA-Z]|[${}])+([a-z]|[${}])+(([.A-Z0-9])+[a-z ]+)+\b/
  * @returns {boolean} true if convention wrong, false if not
  */
 var namingConvention = function( line ) {
-	var arr = line.split( ' ' )
-	var doWeTestRe = /^[${:]+/m // determine if line should be tested at all
+	var doWeTestRe = /[${:]+/m // determine if line should be tested at all
 	var badConvention = false
 
 	if ( this.config.namingConventionStrict === true ) {
-		doWeTestRe = /^[$#.{:]+/m // test a wider range if strict is true
+		doWeTestRe = /[$#.{:]+/m // test a wider range if strict is true
 	}
 
 	// only run checks if on a class, id, or variable
-	if ( doWeTestRe.test( arr[0] ) && arr[0].indexOf( '::' ) === -1 ) {
+	if ( doWeTestRe.test( line ) && line.indexOf( '::' ) === -1 ) {
 		// if all lowercase we do nothing, if -, _ or uppercase found we check convention
-		if ( upperRe.test( arr[0] ) ||
-			arr[0].indexOf( '-' ) !== -1 ||
-			arr[0].indexOf( '_' ) !== -1 ) {
+		if ( upperRe.test( line ) ||
+			line.indexOf( '-' ) !== -1 ||
+			line.indexOf( '_' ) !== -1 ) {
 
 			// check conventions
 			// $varName
 			if ( this.state.conf === 'camelCase' ) {
 				// if no A-Z present, or - present, or _ present
-				if ( arr[0].indexOf( '-' ) !== -1 ||
-					arr[0].indexOf( '_' ) !== -1 ||
-					!camelRe.test( arr[0] ) ) {
+				if ( line.indexOf( '-' ) !== -1 ||
+					line.indexOf( '_' ) !== -1 ||
+					!camelRe.test( line ) ) {
 					badConvention = true
 				}
 			}
 			// $var_name
 			else if ( this.state.conf === 'lowercase_underscore' ) {
 				// if no _ present, or - present, or A-Z present
-				if ( arr[0].indexOf( '-' ) !== -1 ||
-					arr[0].indexOf( '_' ) === -1 ||
-					upperRe.test( arr[0] ) ) {
+				if ( line.indexOf( '-' ) !== -1 ||
+					line.indexOf( '_' ) === -1 ||
+					upperRe.test( line ) ) {
 					badConvention = true
 				}
 			}
 			// $var-name
 			else if ( this.state.conf === 'lowercase-dash' ) {
 				// if no - present, or _ present, or A-Z present
-				if ( arr[0].indexOf( '-' ) === -1 ||
-					arr[0].indexOf( '_' ) !== -1 ||
-					upperRe.test( arr[0] ) ) {
+				if ( line.indexOf( '-' ) === -1 ||
+					line.indexOf( '_' ) !== -1 ||
+					upperRe.test( line ) ) {
 					badConvention = true
 				}
 			}
 			// $var__element
 			else if ( this.state.conf === 'BEM' ) {
 				// if A-Z or not following BEM specification
-				if ( upperRe.test( arr[0] ) || !bemRe.test( arr[0] ) ) {
+				if ( upperRe.test( line ) || !bemRe.test( line ) ) {
 					badConvention = true
 				}
 			}


### PR DESCRIPTION
This fix #168 and improve namingConvention check.

Previously namingConvention function only checks if first item of a splitted line matches the regex tests, now it checks if there's any matches in the whole line.