### PR TITLE
Brackets on always shouldn't fail if line is empty

### DIFF
--- a/src/checks/brackets.js
+++ b/src/checks/brackets.js
@@ -19,6 +19,7 @@ var brackets = function( line ) {
 	// 3 mixin
 	// 4 .selector,
 	if ( this.state.hashOrCSS ||
+		line.trim().length === 0 ||
 		line.indexOf( ' =' ) !== -1 ||
 		parensRe.test( line ) ||
 		commaRe.test( line ) ) {

--- a/test/test.js
+++ b/test/test.js
@@ -532,6 +532,9 @@ describe('Linter Style Checks: ', function() {
 			assert.equal( undefined, bracketsTest('{foo() + "bar"}') )
 			assert.equal( undefined, bracketsTest('$foo = {') )
 		})
+		it('undefined if empty', function() {
+			assert.equal( undefined, bracketsTest('  ') )
+		})
 	})
 
 	describe('brackets: disallow brackets', function() {


### PR DESCRIPTION
With brackets set to always, my linter was failing:
```stylus
my-mixin() {
  {block}
}
```
on the line with `{block}`.  From digging through the source, it seemed like something was stripping out the interpolation, and passing `'  '` to the brackets check, where it was failing.  I wasn't sure where exactly to address this, but here is my attempt.