### PR TITLE
Should exit code be 0 if there are warnings but no errors?

### DIFF
--- a/src/core/done.js
+++ b/src/core/done.js
@@ -8,9 +8,8 @@ var done = function() {
 	var warningsOrErrors = []
 	var msg = ''
 
-	// if no warnings or errors, give clean exit code
-	if ( this.cache.errs.length > 0 ||
-		this.cache.warnings.length > 0 ) {
+	// if no errors, give clean exit code
+	if ( this.cache.errs.length > 0 ) {
 		this.state.exitCode = 1
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -2294,7 +2294,12 @@ describe('Done, again: ', function() {
 		assert.equal( true, typeof app.done().msg === 'string' )
 	})
 
-	it('exit code should be 0 if no errs or warnings', function() {
+	it('exit code should be 0 if no errs', function() {
+		assert.equal( 0, app.done().exitCode )
+	})
+
+	it('exit code should be 0 if has warnings and no errs', function() {
+		app.cache.warnings = [0,1,2,3,4]
 		assert.equal( 0, app.done().exitCode )
 	})
 


### PR DESCRIPTION
I think `eslint` does something similar where warnings won't give a failure exit code.  What do you think?