### PR TITLE
sortOrder: output "custom grouped"

### DIFF
--- a/src/checks/sortOrder.js
+++ b/src/checks/sortOrder.js
@@ -92,7 +92,8 @@ var sortOrder = function( line ) {
 	}
 
 	if ( !sorted ) {
-		this.msg( 'prefer ' + this.state.conf + ' when sorting properties' )
+		var orderingName = Array.isArray( this.state.conf ) ? 'custom grouped' : this.state.conf
+		this.msg( 'prefer ' + orderingName + ' when sorting properties' )
 	}
 
 	return sorted


### PR DESCRIPTION
Very inconvenient when 2 errors fill the entire terminal, so I suggest for arrays in sorting output:
`prefer custom grouped when sorting properties`