### PR TITLE
Fix print from namingConvention

### DIFF
--- a/src/checks/namingConvention.js
+++ b/src/checks/namingConvention.js
@@ -69,7 +69,7 @@ var namingConvention = function( line ) {
 	}
 
 	if ( badConvention ) {
-		this.msg( 'preferred naming convention is ' + this.config.namingConvention )
+		this.msg( 'preferred naming convention is ' + this.state.conf )
 	}
 
 	return badConvention


### PR DESCRIPTION
`preferred naming convention is [object Object]` is the output in case of an object