### PR TITLE
Make option `prefixVarsWithDollar` accept `$-` or `$_` prefix.

### DIFF
--- a/src/checks/prefixVarsWithDollar.js
+++ b/src/checks/prefixVarsWithDollar.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var dollaRe = /\$\w/
+var dollaRe = /\$[\-_]*\w/
 var eqEndRe = /=$|=\s$/
 var ignoreRe = /(\[.+\])|if|for|else|return|@require|@import|@media|@block|vendor-prefixes|calc|(=|= )$|{$/ // 3
 

--- a/test/test.js
+++ b/test/test.js
@@ -1741,6 +1741,8 @@ describe( 'Linter Style Checks: ', function() {
 		it( 'true if $ is found and is correct', function() {
 			assert.ok( varTest( '$my-var = 0' ) )
 			assert.ok( varTest( '$first-value = floor( (100% / $columns) * $index )' ) )
+			assert.ok( varTest( '$-my-private-var = red' ) )
+			assert.ok( varTest( '$_myPrivateVar = red' ) )
 		} )
 
 		it( 'undefined if @block var', function() {


### PR DESCRIPTION
Sometimes we might use `$-` or `$_` prefix to mark private variables, such as:

```stylus
$-my-private-var = red
$_myPrivateVar = red
```

So we need the option `prefixVarsWithDollar` to accept those prefixes.