### PR TITLE
Limit indent counting to beginning of line

### DIFF
--- a/src/utils/setContext.js
+++ b/src/utils/setContext.js
@@ -6,29 +6,18 @@
  * @returns {number} # of indents deep we are
 */
 var setContext = function( line ) {
-	var i = 0
 	var context = 0
-	var whitespace = 0
 	var indentPref = this.config.indentPref.expect || this.config.indentPref
 
 	this.state.prevContext = this.state.context
 
 	// get context if tabs
 	if ( line.charAt( 0 ) === '\t' ) {
-		while ( line.charAt( i++ ) === '\t' ) {
-			context++
-		}
+		context = /^\t+/.exec( line )[0].length
 	}
 	// get context if spaces
-	if ( line.charAt( 0 ) === ' ' ) {
-		line.split( /[\s\t]/ ).forEach( function( val ) {
-			if ( val.length === 0 ) {
-				whitespace++
-			}
-			else {
-				context = whitespace / indentPref
-			}
-		} )
+	else if ( line.charAt( 0 ) === ' ' ) {
+		context = /^\s+/.exec( line )[0].length / indentPref
 	}
 
 	return context


### PR DESCRIPTION
Only count *either* spaces or tabs. (No crazy
mixtures within a single line indent.)

Previously any extra spacing within strings or CSS values,
would count against the indenting/context value,
which is a little bit nuts.