### PR TITLE
cache rule name with error message for reporters to use as they need

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -1,6 +1,6 @@
 var path = require( 'path' )
 
-// the main cache bject
+// the main cache object
 var cache = {
 	comment: '', // the current line comment on the line, if there is one
 	errs: [], // array of errors detected so far
@@ -16,6 +16,7 @@ var cache = {
 	prevFile: '', // the previous file
 	prevFileNo: 0, // prev file no
 	prevLine: '', // the previous line
+	rule: '', // rule name for current check
 	dir: path.dirname( require.main.filename ), // index.js directory
 	sCache: { '0': [] }, // each key is an array of selectors in that context
 	sortOrderCache: [], // we keep a context based arr of selectors here to check sort orde

--- a/src/core/lint.js
+++ b/src/core/lint.js
@@ -14,6 +14,8 @@ var lint = function() {
 	for ( method in checks ) {
 		if ( checks.hasOwnProperty( method ) ) {
 			if ( this.config[method] ) {
+				// save config rule name for use in reporters
+				this.cache.rule = method
 				// state.conf === 'always' || 'never' || etc
 				this.state.conf = this.config[method].expect || this.config[method]
 				// state.severity === 'error' || 'warning'

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -33,6 +33,7 @@ var parse = function( err, res ) {
 			this.cache.origLine = line
 			this.cache.line = this.trimLine( line )
 			this.cache.lineNo = lineNo++
+			this.cache.rule = ''
 			return this.setState( line )
 		}.bind( this ) )
 

--- a/test/test.js
+++ b/test/test.js
@@ -193,6 +193,19 @@ describe( 'Core Methods: ', function() {
 			app.lint()
 			app.lint.getCall( 2 ).returned( sinon.match.same( app.done ) )
 		} )
+
+		it( 'should cache rule name as one of warning properties', function() {
+			app.config = { brackets : 'never'}
+			app.lint()
+			assert.equal( app.cache.rule, 'brackets' )
+
+			app.config = { leadingZero : 'never'}
+			app.lint()
+			assert.equal( app.cache.rule, 'leadingZero' )
+
+			// restore config
+			app.config = app.setConfig()
+		} )
 	} )
 
 	describe( 'Watch: ', function() {


### PR DESCRIPTION
Just like ESLint and sass-lint expose rule name with error message cache. Not every reporter need to use it but will be useful to display it in editor like ESLint do. Possible future use: find automatic fix by rule name and apply it inline (alt+enter inspections in Webstorm IDE).

![stylint-rule](https://cloud.githubusercontent.com/assets/4718998/13968415/e96ab894-f07c-11e5-8649-4e36b4cb47cb.png)

![eslint-rule](https://cloud.githubusercontent.com/assets/4718998/13968410/e19a5642-f07c-11e5-905b-f494c8c4c352.png)

BTW. What's the difference between state and cache objects? Some warning message properties are on state (severity) and some are on cache (lineNo, msg, etc). Did I choose the right one?
