### PR TITLE
[WIP] Add column number to warning message details

### DIFF
--- a/src/checks/blocks.js
+++ b/src/checks/blocks.js
@@ -14,18 +14,19 @@ var blocks = function( line ) {
 	var block
 
 	// if = ends the line and not a block var or hash
-	if ( line.indexOf( '@block' ) === -1 && eqEndRe.test( line ) ) {
+	var indexOfBlock = line.indexOf( '@block' );
+    if ( indexOfBlock === -1 && eqEndRe.test( line ) ) {
 		block = false
 	}
-	else if ( line.indexOf( '@block' ) !== -1 ) {
+	else if ( indexOfBlock !== -1 ) {
 		block = true
 	}
 
 	if ( this.state.conf === 'always' && block === false ) {
-		this.msg( 'block variables must include @block' )
+		this.msg( 'block variables must include @block', line.length )
 	}
 	else if ( this.state.conf === 'never' && block === true ) {
-		this.msg( '@block is not allowed' )
+		this.msg( '@block is not allowed', indexOfBlock )
 	}
 
 	return block

--- a/src/checks/blocks.js
+++ b/src/checks/blocks.js
@@ -14,8 +14,8 @@ var blocks = function( line ) {
 	var block
 
 	// if = ends the line and not a block var or hash
-	var indexOfBlock = line.indexOf( '@block' );
-    if ( indexOfBlock === -1 && eqEndRe.test( line ) ) {
+	var indexOfBlock = line.indexOf( '@block' )
+	if ( indexOfBlock === -1 && eqEndRe.test( line ) ) {
 		block = false
 	}
 	else if ( indexOfBlock !== -1 ) {

--- a/src/checks/brackets.js
+++ b/src/checks/brackets.js
@@ -35,11 +35,13 @@ var brackets = function( line ) {
 			line.indexOf( '=' ) === -1 &&
 			line.indexOf( '}' ) === -1 ) {
 			bracket = true
+			this.state.openBracket = true
 		}
 		// ex: } is okay if ending a hash. otherwise it is NOT okay
 		// one liners are lame but ok ( check for = { )
 		else if ( line.indexOf( '}' ) !== -1 && line.indexOf( '{' ) === -1 ) {
 			bracket = true
+			this.state.openBracket = false
 		}
 	}
 	else if ( this.state.conf === 'always' ) {
@@ -75,10 +77,10 @@ var brackets = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && bracket === true ) {
-		this.msg( 'unecessary bracket' )
+		this.msg( 'unecessary bracket', line.indexOf( this.state.openBracket ? '{' : '}' ) )
 	}
 	else if ( this.state.conf === 'always' && bracket === false ) {
-		this.msg( 'always use brackets when defining selectors' )
+		this.msg( 'always use brackets when defining selectors', line.length + 1 )
 	}
 
 	return bracket

--- a/src/checks/colons.js
+++ b/src/checks/colons.js
@@ -20,10 +20,11 @@ var colons = function( line ) {
 	var colon
 	var hasPseudo = false
 	var arr = this.splitAndStrip( new RegExp( /\s/ ), line )
-
-	if ( this.state.conf === 'always' &&
+	var propertyName = arr[0];
+	
+    if ( this.state.conf === 'always' &&
 		arr.length > 1 &&
-		arr[0].indexOf( ':' ) === -1 ) {
+		propertyName.indexOf( ':' ) === -1 ) {
 		colon = false
 	}
 	// : is allowed in hashes
@@ -43,10 +44,10 @@ var colons = function( line ) {
 	}
 
 	if ( this.state.conf === 'always' && colon === false ) {
-		this.msg( 'missing colon between property and value' )
+		this.msg( 'missing colon between property and value', line.indexOf( propertyName ) + propertyName.length )
 	}
 	else if ( this.state.conf === 'never' && colon === true ) {
-		this.msg( 'unecessary colon found' )
+		this.msg( 'unecessary colon found', line.indexOf( ':' ) )
 	}
 
 	return colon

--- a/src/checks/colons.js
+++ b/src/checks/colons.js
@@ -20,9 +20,9 @@ var colons = function( line ) {
 	var colon
 	var hasPseudo = false
 	var arr = this.splitAndStrip( new RegExp( /\s/ ), line )
-	var propertyName = arr[0];
-	
-    if ( this.state.conf === 'always' &&
+	var propertyName = arr[0]
+
+	if ( this.state.conf === 'always' &&
 		arr.length > 1 &&
 		propertyName.indexOf( ':' ) === -1 ) {
 		colon = false

--- a/src/checks/colors.js
+++ b/src/checks/colors.js
@@ -16,11 +16,10 @@ var colors = function( line ) {
 	// so basically if we're using #hex colors outside of a var declaration
 	if ( hexRe.test( line ) ) {
 		hex = true
-		this.cache.columnNo = line.search(hexRe)
 	}
 
 	if ( hex === true ) {
-		this.msg( 'hexidecimal color should be a variable' )
+		this.msg( 'hexidecimal color should be a variable', line.search(hexRe) )
 	}
 
 	return hex

--- a/src/checks/colors.js
+++ b/src/checks/colors.js
@@ -16,6 +16,7 @@ var colors = function( line ) {
 	// so basically if we're using #hex colors outside of a var declaration
 	if ( hexRe.test( line ) ) {
 		hex = true
+		this.cache.columnNo = line.search(hexRe)
 	}
 
 	if ( hex === true ) {

--- a/src/checks/colors.js
+++ b/src/checks/colors.js
@@ -19,7 +19,7 @@ var colors = function( line ) {
 	}
 
 	if ( hex === true ) {
-		this.msg( 'hexidecimal color should be a variable', line.search(hexRe) )
+		this.msg( 'hexidecimal color should be a variable', line.search( hexRe ) )
 	}
 
 	return hex

--- a/src/checks/commaSpace.js
+++ b/src/checks/commaSpace.js
@@ -28,11 +28,11 @@ var commaSpace = function( line ) {
 
 	// if spaces should be follow commas, but there is no space on the line
 	if ( this.state.conf === 'always' && noSpaceRe.test( trimmedLine ) ) {
-		this.msg( 'commas must be followed by a space for readability' )
+		this.msg( 'commas must be followed by a space for readability', line.search( noSpaceRe ) )
 	}
 	// if spaces should not be followed by a comma, but there are spaces anyway
 	else if ( this.state.conf === 'never' && withSpaceRe.test( trimmedLine ) ) {
-		this.msg( 'spaces after commas are not allowed' )
+		this.msg( 'spaces after commas are not allowed', line.search( withSpaceRe ) )
 	}
 
 	return noSpaceRe.test( trimmedLine ) && !withSpaceRe.test( trimmedLine )

--- a/src/checks/commentSpace.js
+++ b/src/checks/commentSpace.js
@@ -19,10 +19,10 @@ var commentSpace = function() {
 	var emptyComment = /\/\/$/.test( this.cache.comment )
 
 	if ( this.state.conf === 'always' && spaceAfterComment === false && !emptyComment ) {
-		this.msg( 'line comments require a space after //' )
+		this.msg( 'line comments require a space after //', this.cache.origLine.indexOf( '//' ) )
 	}
 	else if ( this.state.conf === 'never' && spaceAfterComment === true ) {
-		this.msg( 'spaces after line comments disallowed' )
+		this.msg( 'spaces after line comments disallowed', this.cache.origLine.indexOf( '//' ) )
 	}
 
 	return spaceAfterComment

--- a/src/checks/cssLiteral.js
+++ b/src/checks/cssLiteral.js
@@ -11,8 +11,8 @@ var cssLiteral = function( line ) {
 	if ( this.state.hashOrCSS ) { return }
 	var isCSSLiteral = false
 
-	var indexOfCss = line.indexOf( '@css' );
-    if ( indexOfCss !== -1 ) {
+	var indexOfCss = line.indexOf( '@css' )
+	if ( indexOfCss !== -1 ) {
 		isCSSLiteral = true
 	}
 

--- a/src/checks/cssLiteral.js
+++ b/src/checks/cssLiteral.js
@@ -11,12 +11,13 @@ var cssLiteral = function( line ) {
 	if ( this.state.hashOrCSS ) { return }
 	var isCSSLiteral = false
 
-	if ( line.indexOf( '@css' ) !== -1 ) {
+	var indexOfCss = line.indexOf( '@css' );
+    if ( indexOfCss !== -1 ) {
 		isCSSLiteral = true
 	}
 
 	if ( this.state.conf === 'never' && isCSSLiteral === true ) {
-		this.msg( 'css literals are disallowed' )
+		this.msg( 'css literals are disallowed', indexOfCss )
 	}
 
 	return isCSSLiteral

--- a/src/checks/depthLimit.js
+++ b/src/checks/depthLimit.js
@@ -26,7 +26,7 @@ var depthLimit = function( line ) {
 	}
 
 	if ( badNesting === true ) {
-		this.msg( 'selector depth greater than ' + limit )
+		this.msg( 'selector depth greater than ' + limit, 0 )
 	}
 
 	return badNesting

--- a/src/checks/duplicates.js
+++ b/src/checks/duplicates.js
@@ -44,6 +44,7 @@ var duplicates = function( line ) {
 	// then dupe
 	if ( line.indexOf( ',' ) === -1 &&
 		this.cache.prevLine.indexOf( ',' ) === -1 &&
+		typeof arr[0] !== 'undefined' &&
 		!ignoreRe.test( line ) ) {
 
 		// -1 if no dupe found
@@ -62,10 +63,9 @@ var duplicates = function( line ) {
 		// location of original selector use if global dupe on
 		origFile = this.cache.sCache[this.state.context][dupeIndex + 1]
 
-		// this.msg( 'duplicate property or selector, consider merging' )
 		if ( !this.config.globalDupe ) {
 			this.msg(
-				'duplicate property or selector, consider merging'
+				'duplicate property or selector, consider merging', line.indexOf( arr[0].replace( /^[\.|#]/, '' ) )
 			)
 		}
 		else {

--- a/src/checks/efficient.js
+++ b/src/checks/efficient.js
@@ -41,10 +41,10 @@ var efficient = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && isEfficient === true ) {
-		this.msg( 'the value on this line is too succinct' )
+		this.msg( 'the value on this line is too succinct', line.indexOf( arr[1] ) )
 	}
 	else if ( this.state.conf === 'always' && isEfficient === false ) {
-		this.msg( 'the value on this line could be more succinct' )
+		this.msg( 'the value on this line could be more succinct', line.indexOf( arr[1] ) )
 	}
 
 	return isEfficient

--- a/src/checks/extendPref.js
+++ b/src/checks/extendPref.js
@@ -15,10 +15,12 @@ var extendPref = function( line ) {
 	// extremely petty, i know
 	if ( this.state.conf === '@extends' && line.indexOf( '@extends ' ) === -1 ) {
 		extendIncorrect = true
+		this.cache.columnNo = line.indexOf(  '@extend'  )
 	}
 	// else @extend is your pref
 	else if ( this.state.conf === '@extend' && line.indexOf( '@extend ' ) === -1 ) {
 		extendIncorrect = true
+		this.cache.columnNo = line.indexOf( '@extends' )
 	}
 
 	if ( extendIncorrect === true ) {

--- a/src/checks/extendPref.js
+++ b/src/checks/extendPref.js
@@ -10,21 +10,22 @@ var extendPref = function( line ) {
 	if ( line.indexOf( '@extend' ) === -1 ) { return }
 
 	var extendIncorrect = false
+	var column = -1
 
 	// prefer @extends to @extend
 	// extremely petty, i know
 	if ( this.state.conf === '@extends' && line.indexOf( '@extends ' ) === -1 ) {
 		extendIncorrect = true
-		this.cache.columnNo = line.indexOf(  '@extend'  )
+		column = line.indexOf(  '@extend'  )
 	}
 	// else @extend is your pref
 	else if ( this.state.conf === '@extend' && line.indexOf( '@extend ' ) === -1 ) {
 		extendIncorrect = true
-		this.cache.columnNo = line.indexOf( '@extends' )
+		column = line.indexOf( '@extends' )
 	}
 
 	if ( extendIncorrect === true ) {
-		this.msg( 'please use ' + this.state.conf )
+		this.msg( 'please use ' + this.state.conf, column )
 	}
 
 	return extendIncorrect

--- a/src/checks/extendPref.js
+++ b/src/checks/extendPref.js
@@ -16,7 +16,7 @@ var extendPref = function( line ) {
 	// extremely petty, i know
 	if ( this.state.conf === '@extends' && line.indexOf( '@extends ' ) === -1 ) {
 		extendIncorrect = true
-		column = line.indexOf(  '@extend'  )
+		column = line.indexOf( '@extend' )
 	}
 	// else @extend is your pref
 	else if ( this.state.conf === '@extend' && line.indexOf( '@extend ' ) === -1 ) {

--- a/src/checks/indentPref.js
+++ b/src/checks/indentPref.js
@@ -15,7 +15,7 @@ var indentPref = function() {
 	}
 
 	if ( indentCorrect === false ) {
-		this.msg( 'incorrect # of spaces for indent, use ' + this.state.conf )
+		this.msg( 'incorrect # of spaces for indent, use ' + this.state.conf, 0 )
 	}
 
 	return indentCorrect

--- a/src/checks/leadingZero.js
+++ b/src/checks/leadingZero.js
@@ -1,8 +1,9 @@
 'use strict'
 
 var decimalRe = /[^\d+](0+\.\d+)|[\s,\(](\.\d+)/i
-var leadZeroRe = /[^\d+](0+\.\d+)/
-var nonZeroRe = /[\s,\(](\.\d+)/
+var leadZeroRe = /[^\d+](0+\.\d+)/g
+var nonZeroRe = /[\s,\(](\.\d+)/g
+var match
 
 
 /**
@@ -13,17 +14,21 @@ var nonZeroRe = /[\s,\(](\.\d+)/
 var leadingZero = function( line ) {
 	if ( !decimalRe.test( line ) ) { return }
 
-	var leadZeroFound = leadZeroRe.test( line )
-	var leadZeroMissing = nonZeroRe.test( line )
+	leadZeroRe.lastIndex = 0
+	nonZeroRe.lastIndex = 0
 
-	if ( this.state.conf === 'always' && leadZeroMissing ) {
-		this.msg( 'leading zeros for decimal points are required' )
+	if ( this.state.conf === 'always' ) {
+		while ( ( match = nonZeroRe.exec( line ) ) !== null ) {
+			this.msg( 'leading zeros for decimal points are required', line.indexOf( match[1], match.index ) )
+		}
 	}
-	else if ( this.state.conf === 'never' && leadZeroFound ) {
-		this.msg( 'leading zeros for decimal points are unnecessary' )
+	else if ( this.state.conf === 'never' ) {
+		while ( ( match = leadZeroRe.exec( line ) ) !== null ) {
+			this.msg( 'leading zeros for decimal points are unnecessary', line.indexOf( match[1], match.index ) )
+		}
 	}
 
-	return leadZeroFound
+	return leadZeroRe.test( line )
 }
 
 module.exports = leadingZero

--- a/src/checks/mixed.js
+++ b/src/checks/mixed.js
@@ -27,7 +27,7 @@ var mixed = function( line ) {
 	}
 
 	if ( isMixed === true ) {
-		this.msg( 'mixed spaces and tabs' )
+		this.msg( 'mixed spaces and tabs', 0 )
 	}
 
 	return isMixed

--- a/src/checks/namingConvention.js
+++ b/src/checks/namingConvention.js
@@ -69,7 +69,10 @@ var namingConvention = function( line ) {
 	}
 
 	if ( badConvention === true ) {
-		this.msg( 'preferred naming convention is ' + this.state.conf )
+		this.msg(
+			'preferred naming convention is ' + this.state.conf + ': ' + arr[0],
+			line.indexOf( arr[0].replace( doWeTestRe, '' ) )
+		)
 	}
 
 	return badConvention

--- a/src/checks/noImportant.js
+++ b/src/checks/noImportant.js
@@ -10,7 +10,7 @@ var noImportant = function( line ) {
 	var important = false
 
 	var indexOfImportant = line.indexOf( '!important' );
-    if ( indexOfImportant !== -1 ) {
+	if ( indexOfImportant !== -1 ) {
 		important = true
 		this.cache.columnNo = indexOfImportant
 	}

--- a/src/checks/noImportant.js
+++ b/src/checks/noImportant.js
@@ -12,11 +12,10 @@ var noImportant = function( line ) {
 	var indexOfImportant = line.indexOf( '!important' );
 	if ( indexOfImportant !== -1 ) {
 		important = true
-		this.cache.columnNo = indexOfImportant
 	}
 
 	if ( important === true ) {
-		this.msg( '!important is disallowed ' )
+		this.msg( '!important is disallowed ', indexOfImportant )
 	}
 
 	return important

--- a/src/checks/noImportant.js
+++ b/src/checks/noImportant.js
@@ -9,9 +9,10 @@
 var noImportant = function( line ) {
 	var important = false
 
-	// return true if border|outline is followed by a 0
-	if ( line.indexOf( '!important' ) !== -1 ) {
+	var indexOfImportant = line.indexOf( '!important' );
+    if ( indexOfImportant !== -1 ) {
 		important = true
+		this.cache.columnNo = indexOfImportant
 	}
 
 	if ( important === true ) {

--- a/src/checks/noImportant.js
+++ b/src/checks/noImportant.js
@@ -9,7 +9,7 @@
 var noImportant = function( line ) {
 	var important = false
 
-	var indexOfImportant = line.indexOf( '!important' );
+	var indexOfImportant = line.indexOf( '!important' )
 	if ( indexOfImportant !== -1 ) {
 		important = true
 	}

--- a/src/checks/none.js
+++ b/src/checks/none.js
@@ -23,14 +23,14 @@ var none = function( line ) {
 	// enforce use of none
 	if ( this.state.conf === 'always' && zeroRe.test( line ) && !noneRe.test( line ) ) {
 		badSyntax = true
-		this.msg( 'none is preferred over 0' )
+		this.msg( 'none is preferred over 0', line.search( '0' ) )
 	}
 	// return true if border|outline is followed by none
 	// enforce use of 0
 	else if ( this.state.conf === 'never' &&
 		noneRe.test( line ) && !zeroRe.test( line ) ) {
 		badSyntax = true
-		this.msg( '0 is preferred over none' )
+		this.msg( '0 is preferred over none', line.search( 'none' ) )
 	}
 
 	return badSyntax

--- a/src/checks/parenSpace.js
+++ b/src/checks/parenSpace.js
@@ -17,10 +17,10 @@ var parenSpace = function( line ) {
 	var hasEndSpace = parensEndWithSpaceRe.test( line )
 
 	if ( this.state.conf === 'always' && !( hasStartSpace && hasEndSpace ) ) {
-		this.msg( '( param1, param2 ) is preferred over (param1, param2)' )
+		this.msg( '( param1, param2 ) is preferred over (param1, param2)', line.search( /\(\S+|\)+/ ) )
 	}
 	else if ( this.state.conf === 'never' && ( hasStartSpace || hasEndSpace ) ) {
-		this.msg( '(param1, param2) is preferred over ( param1, param2 )' )
+		this.msg( '(param1, param2) is preferred over ( param1, param2 )', line.search( /\(\s+|\)+/ ) )
 	}
 
 	return hasStartSpace && hasEndSpace

--- a/src/checks/placeholders.js
+++ b/src/checks/placeholders.js
@@ -1,6 +1,8 @@
 'use strict'
 
-var placeholderRe = /(@extend|@extends)+( \$)+/
+var extendRe = /@extends?\s/
+var placeholderRe = /(\$[^,;\s]*)/
+var nonPlaceholderRe = /([\.|#][^,;\s]*)/
 
 
 /**
@@ -11,21 +13,18 @@ var placeholderRe = /(@extend|@extends)+( \$)+/
 var placeholders = function( line ) {
 	if ( line.indexOf( '@extend' ) === -1 ) { return }
 
-	var placeholder = false
-
-	// first check if line has an extend, then check for placeholder
-	if ( placeholderRe.test( line ) ) {
-		placeholder = true
+	if ( !extendRe.test( line ) ) {
+		return false
 	}
 
-	if ( this.state.conf === 'always' && placeholder === false ) {
-		this.msg( 'use a placeholder variable when extending' )
+	if ( this.state.conf === 'always' && nonPlaceholderRe.test( line ) ) {
+		this.msg( 'use a placeholder variable when extending', line.search( nonPlaceholderRe ) )
 	}
-	else if ( this.state.conf === 'never' && placeholder === true ) {
-		this.msg( 'placeholder variables are disallowed' )
+	else if ( this.state.conf === 'never' && placeholderRe.test( line ) ) {
+		this.msg( 'placeholder variables are disallowed', line.search( placeholderRe ) )
 	}
 
-	return placeholder
+	return placeholderRe.test( line )
 }
 
 module.exports = placeholders

--- a/src/checks/semicolons.js
+++ b/src/checks/semicolons.js
@@ -19,14 +19,15 @@ var semicolons = function( line ) {
 
 	var semicolon
 
+	var indexOfSemicolon = line.indexOf( ';' )
 	if ( this.state.conf === 'never' &&
-		line.indexOf( ';' ) !== -1 ) {
+		indexOfSemicolon !== -1 ) {
 		semicolon = true
 	}
 	else if ( this.state.conf === 'always' &&
 		this.state.context > 0 ) {
 
-		if ( line.indexOf( ';' ) === -1 &&
+		if ( indexOfSemicolon === -1 &&
 			line.indexOf( '}' ) === -1 &&
 			line.indexOf( '{' ) === -1 ) {
 
@@ -35,10 +36,10 @@ var semicolons = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && semicolon === true ) {
-		this.msg( 'unecessary semicolon found' )
+		this.msg( 'unecessary semicolon found', indexOfSemicolon )
 	}
 	else if ( this.state.conf === 'always' && semicolon === false ) {
-		this.msg( 'missing semicolon' )
+		this.msg( 'missing semicolon', line.length )
 	}
 
 	return semicolon

--- a/src/checks/sortOrder.js
+++ b/src/checks/sortOrder.js
@@ -103,7 +103,7 @@ var sortOrder = function( line ) {
 	}
 
 	if ( sorted === false ) {
-		this.msg( 'prefer ' + orderName + ' when sorting properties' )
+		this.msg( 'prefer ' + orderName + ' when sorting properties', line.indexOf( arr[0] ) )
 	}
 
 	return sorted

--- a/src/checks/stackedProperties.js
+++ b/src/checks/stackedProperties.js
@@ -19,7 +19,7 @@ var stackedProperties = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && oneLiner === true ) {
-		this.msg( 'avoid one liners. put properties on their own line' )
+		this.msg( 'avoid one liners. put properties on their own line', -1 )
 	}
 
 	return oneLiner

--- a/src/checks/trailingWhitespace.js
+++ b/src/checks/trailingWhitespace.js
@@ -20,7 +20,7 @@ var trailingWhitespace = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && whitespace === true ) {
-		this.msg( 'trailing whitespace' )
+		this.msg( 'trailing whitespace', line.search( whitespaceRe ) )
 	}
 
 	return whitespace

--- a/src/checks/universal.js
+++ b/src/checks/universal.js
@@ -14,14 +14,15 @@ var universal = function( line ) {
 	var hasUniversal = false
 
 	// content can have a string that could be anything, so ignore those
-	if ( line.indexOf( '*' ) !== -1 && line.indexOf( 'content' ) === -1 ) {
+	var indexOfUniversal = line.indexOf( '*' );
+    if ( indexOfUniversal !== -1 && line.indexOf( 'content' ) === -1 ) {
 		if ( !universalRe.test( line ) ) {
 			hasUniversal = true
 		}
 	}
 
 	if ( this.state.conf === 'never' && hasUniversal === true ) {
-		this.msg( '* selector is disallowed' )
+		this.msg( '* selector is disallowed', indexOfUniversal )
 	}
 
 	return hasUniversal

--- a/src/checks/universal.js
+++ b/src/checks/universal.js
@@ -14,8 +14,8 @@ var universal = function( line ) {
 	var hasUniversal = false
 
 	// content can have a string that could be anything, so ignore those
-	var indexOfUniversal = line.indexOf( '*' );
-    if ( indexOfUniversal !== -1 && line.indexOf( 'content' ) === -1 ) {
+	var indexOfUniversal = line.indexOf( '*' )
+	if ( indexOfUniversal !== -1 && line.indexOf( 'content' ) === -1 ) {
 		if ( !universalRe.test( line ) ) {
 			hasUniversal = true
 		}

--- a/src/checks/valid.js
+++ b/src/checks/valid.js
@@ -72,7 +72,7 @@ module.exports = function valid( line ) {
 	}
 
 	if ( isValid === false ) {
-		this.msg( 'property is not valid' )
+		this.msg( 'property is not valid', line.indexOf( arr[0] ) )
 	}
 
 	return isValid

--- a/src/checks/zIndexNormalize.js
+++ b/src/checks/zIndexNormalize.js
@@ -8,7 +8,7 @@
 */
 var zIndexNormalize = function( line ) {
 	var badZIndex = false
-	var arr = this.splitAndStrip( new RegExp( /[\s\t,:]/ ), line )
+	var arr = this.splitAndStrip( new RegExp( /[\s\t,:;]/ ), line )
 
 	// ignore 0 or -1 values
 	if ( arr[ arr.length - 1 ] === '-1' ||
@@ -21,7 +21,7 @@ var zIndexNormalize = function( line ) {
 	}
 
 	if ( badZIndex === true ) {
-		this.msg( 'this z-index value is not normalized' )
+		this.msg( 'this z-index value is not normalized', line.indexOf( arr[ arr.length - 1 ] ) )
 	}
 
 	return badZIndex

--- a/src/checks/zeroUnits.js
+++ b/src/checks/zeroUnits.js
@@ -34,10 +34,10 @@ var zeroUnits = function( line ) {
 	}
 
 	if ( this.state.conf === 'never' && isCorrect === false ) {
-		this.msg( '0 is preferred. Unit value is unnecessary' )
+		this.msg( '0 is preferred. Unit value is unnecessary', line.search( '0' ) )
 	}
 	else if ( this.state.conf === 'always' && isCorrect === false ) {
-		this.msg( 'Including the unit value is preferred' )
+		this.msg( 'Including the unit value is preferred', line.search( '0' ) )
 	}
 
 	return isCorrect

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -10,6 +10,7 @@ var cache = {
 	fileNo: 0, // curr # of filesLen we're on
 	line: '', // curr line we're testing
 	lineNo: 0, // curr line number we're testing
+	columnNo: -1, // column where error was found
 	mixins: [], // an array of all declared mixins
 	msg: '', // the done message (55 warnings blah blah)
 	origLine: '', // original line before stripping/trimming

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -32,6 +32,7 @@ var parse = function( err, res ) {
 			this.cache.line = this.trimLine( line )
 			this.cache.lineNo = lineNo + 1 // line nos don't start at 0
 			this.cache.rule = ''
+			this.cache.columnNo = -1
 			return this.setState( line )
 		}.bind( this ) )
 

--- a/src/utils/msg.js
+++ b/src/utils/msg.js
@@ -3,10 +3,13 @@
 /**
  * @description basically just sets the severity and routes output to the reporter
  * @param {string} [str] outputted string from one of the checks
+ * @param {number} [column] column where error was found
  * @returns {Function} push formatted output to appropriate array
 */
-var msg = function( str ) {
+var msg = function( str, column ) {
 	var arr
+
+	this.cache.columnNo = typeof column !== 'undefined' ? column : -1; 
 
 	// determine which group the msg belongs to
 	arr = this.state.severity === 'Warning' ? this.cache.warnings : this.cache.errs

--- a/src/utils/msg.js
+++ b/src/utils/msg.js
@@ -9,7 +9,7 @@
 var msg = function( str, column ) {
 	var arr
 
-	this.cache.columnNo = typeof column !== 'undefined' ? column : -1; 
+	this.cache.columnNo = typeof column !== 'undefined' ? column : -1
 
 	// determine which group the msg belongs to
 	arr = this.state.severity === 'Warning' ? this.cache.warnings : this.cache.errs


### PR DESCRIPTION
:warning: WORK IN PROGRESS :warning:

Since I will have to touch every file in checks folder I'm starting this PR early to ask for opinion. I will continue to add columnNo for each check in following commits.

ESLint and sass-lint reporters have column number where the warning occurred. This will allow to highlight the right place in the code editor instead of the whole line.

![stylint-columnno-1](https://cloud.githubusercontent.com/assets/4718998/13969257/fe929ebc-f081-11e5-947c-365e9bd5abc8.png)
![stylint-columnno-2](https://cloud.githubusercontent.com/assets/4718998/13969259/fe979160-f081-11e5-9955-347270303aaa.png)
![stylint-columnno-3](https://cloud.githubusercontent.com/assets/4718998/13969258/fe9636c6-f081-11e5-8c6c-863f1170efd0.png)

Return -1 by default if whole line should be highlighted or check does not support column number (yet).

TODO:

- [x] blocks
- [x] brackets
- [x] colons
- [x] colors
- [x] commaSpace
- [x] commentSpace
- [x] cssLiteral
- [x] depthLimit
- [x] duplicates
- [x] efficient
- [x] extendPref
- [x] indentPref
- [x] leadingZero
- [x] mixed
- [x] namingConvention
- [x] none
- [x] noImportant
- [x] parenSpace
- [x] placeholders
- [ ] prefixVarsWithDollar
- [ ] quotePref
- [x] semicolons
- [x] sortOrder
- [x] stackedProperties
- [x] trailingWhitespace
- [x] universal
- [x] valid
- [x] zeroUnits
- [x] zIndexNormalize