### PR TITLE
Add option to set custom reporter module from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ you can also ping me [here](https://gitter.im/rossPatton/stylint)
 
 `stylint --config path/to/config/.configrc` Run stylint with custom config settings
 
+`stylint --reporter stylint-reporter-module` Run stylint with [custom reporter](#custom-reporters) module
+
 `stylint styl/ --watch -c path/to/config/.configrc` Watch dir, use custom config
 
 

--- a/bin/stylint
+++ b/bin/stylint
@@ -25,7 +25,8 @@ var options = yargs
 	.option( 'reporter', {
 		alias: 'r',
 		describe: 'Custom reporter npm module name',
-		type: 'string'
+		type: 'string',
+		requiresArg: true
 	} )
 	.version( function() {
 		return 'Stylint version: ' + require( '../package' ).version

--- a/bin/stylint
+++ b/bin/stylint
@@ -22,6 +22,11 @@ var options = yargs
 		describe: 'Run all tests, regardless of config',
 		type: 'boolean'
 	} )
+	.option( 'reporter', {
+		alias: 'r',
+		describe: 'Custom reporter npm module name',
+		type: 'string'
+	} )
 	.version( function() {
 		return 'Stylint version: ' + require( '../package' ).version
 	} )
@@ -36,5 +41,6 @@ var options = yargs
 stylint().create( {}, {
 	watch: options.watch,
 	config: options.config,
-	strict: options.strict
+	strict: options.strict,
+	reporter: options.reporter
 }, options._[0] )

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -28,7 +28,10 @@ var init = function( options, pathPassed ) {
 
 	// we do the check here just in case
 	// they don't pass in a reporter when using a custom config
-	if ( this.config.reporter ) {
+	if ( options.reporter ) {
+		this.reporter = require( options.reporter )
+	}
+	else if ( this.config.reporter ) {
 		this.reporter = require( this.config.reporter )
 	}
 	else {


### PR DESCRIPTION
Automatic tool like IDE plugin or CI server can depend on custom reporter. Right now user has to configure it in `.stylintrc` file. This adds configuration step or place for an error.

CLI option has the highest priority. Even if user has different reporter configured in his `.stylintrc` file the CLI will ignore it. This way he can use stylish reporter for his daily work and plugin/ci server will use whatever it needs anyway.