### PR TITLE
Fix leading zero to pass tests

### DIFF
--- a/src/checks/leadingZero.js
+++ b/src/checks/leadingZero.js
@@ -1,14 +1,14 @@
 'use strict'
 
-var decimalRe = /(?:^|[^a-z])\.\d/i
-var leadZeroRe = /(?:^|\D)0\.\d/
-var nonZeroRe = /(?:^|\D)\.\d/
+var decimalRe = /[^\d+](0+\.\d+)|[\s,\(](\.\d+)/i
+var leadZeroRe = /[^\d+](0+\.\d+)/
+var nonZeroRe = /[\s,\(](\.\d+)/
 
 
 /**
  * @description check for leading 0 on numbers ( 0.5 )
  * @param {string} [line] curr line being linted
- * @returns {boolean} true if mixed, false if not
+ * @returns {boolean|undefined} true if mixed, false if not
  */
 var leadingZero = function( line ) {
 	if ( !decimalRe.test( line ) ) { return }
@@ -20,7 +20,7 @@ var leadingZero = function( line ) {
 		this.msg( 'leading zeros for decimal points are required' )
 	}
 	else if ( this.state.conf === 'never' && leadZeroFound ) {
-		this.msg( 'leading zeros for decimal points are unecessary' )
+		this.msg( 'leading zeros for decimal points are unnecessary' )
 	}
 
 	return leadZeroFound

--- a/test/test.js
+++ b/test/test.js
@@ -1305,21 +1305,28 @@ describe( 'Linter Style Checks: ', function() {
 		it( 'false if leading zero not found', function() {
 			assert.equal( false, zeroTest( 'color (0, 0, 0, .18)' ) )
 			assert.equal( false, zeroTest( 'color (0,0,0,.18)' ) )
-			assert.equal( false, zeroTest( 'for $ in (0..9)' ) )
+			assert.equal( false, zeroTest( 'font-size .9em' ) )
+			assert.equal( false, zeroTest( 'transform rotate( .33deg )' ) )
+			assert.equal( false, zeroTest( 'transform rotate(.33deg)' ) )
 		} )
 
 		it( 'true if line has a zero before a decimal point and not part of range', function() {
 			assert.ok( zeroTest( 'color (0, 0, 0, 0.18)' ) )
 			assert.ok( zeroTest( 'color (0,0,0,0.18)' ) )
+			assert.ok( zeroTest( 'transform rotate(0.33deg)' ) )
+			assert.ok( zeroTest( 'transform rotate( 0.33deg )' ) )
 		} )
 
 		it( 'undefined if range', function() {
-			assert.equal( false, zeroTest( 'for 0..9' ) )
-			assert.equal( false, zeroTest( 'for 0...9' ) )
+			assert.equal( undefined, zeroTest( 'for 0..9' ) )
+			assert.equal( undefined, zeroTest( 'for 0...9' ) )
+			assert.equal( undefined, zeroTest( 'for $ in (0..9)' ) )
 		} )
 
-		it( 'false if leading num not zero', function() {
-			assert.equal( false, zeroTest( 'font-size: 1.1em' ) )
+		it( 'undefined if leading num not zero', function() {
+			assert.equal( undefined, zeroTest( 'font-size: 1.1em' ) )
+			assert.equal( undefined, zeroTest( 'transform rotate( 22.33deg )' ) )
+			assert.equal( undefined, zeroTest( 'width 33.3333333%' ) )
 		} )
 
 		it( 'undefined if no .\d in line', function() {
@@ -1339,21 +1346,28 @@ describe( 'Linter Style Checks: ', function() {
 		it( 'false if leading zero not found', function() {
 			assert.equal( false, zeroTest( 'color (0, 0, 0, .18)' ) )
 			assert.equal( false, zeroTest( 'color (0,0,0,.18)' ) )
-			assert.equal( false, zeroTest( 'for $ in (0..9)' ) )
+			assert.equal( false, zeroTest( 'font-size .9em' ) )
+			assert.equal( false, zeroTest( 'transform rotate( .33deg )' ) )
+			assert.equal( false, zeroTest( 'transform rotate(.33deg)' ) )
 		} )
 
 		it( 'false if range', function() {
-			assert.equal( false, zeroTest( 'for 0..9' ) )
-			assert.equal( false, zeroTest( 'for 0...9' ) )
+			assert.equal( undefined, zeroTest( 'for 0..9' ) )
+			assert.equal( undefined, zeroTest( 'for 0...9' ) )
+			assert.equal( undefined, zeroTest( 'for $ in (0..9)' ) )
 		} )
 
 		it( 'true if line has a zero before a decimal point and', function() {
 			assert.ok( zeroTest( 'color (0, 0, 0, 0.18)' ) )
 			assert.ok( zeroTest( 'color (0,0,0,0.18)' ) )
+			assert.ok( zeroTest( 'transform rotate(0.33deg)' ) )
+			assert.ok( zeroTest( 'transform rotate( 0.33deg )' ) )
 		} )
 
 		it( 'undefined if leading num not zero', function() {
-			assert.equal( false, zeroTest( 'font-size: 1.1em' ) )
+			assert.equal( undefined, zeroTest( 'font-size: 1.1em' ) )
+			assert.equal( undefined, zeroTest( 'transform rotate( 22.33deg )' ) )
+			assert.equal( undefined, zeroTest( 'width 33.3333333%' ) )
 		} )
 
 		it( 'undefined if no . in line', function() {


### PR DESCRIPTION
One of PRs broke "undefined if range" tests, allowing them to pass first regex.

I've rearranged "range" tests and added few more fore brackets and spacing test. Travis should be happy now. 