### PR TITLE
Move all this.config writes to setConfig method

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -11,6 +11,7 @@
   "depthLimit": 4,
   "duplicates": true,
   "efficient": "always",
+  "exclude": [],
   "extendPref": false,
   "globalDupe": false,
   "indentPref": 2,

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -20,9 +20,6 @@ var init = function( options, pathPassed ) {
 
 	this.config = this.setConfig( options.config )
 
-	// make sure indentPref is set no matter what
-	this.config.indentPref = this.config.indentPref || false
-
 	// if you want to use transparent mixins, pass in an array of them
 	this.cache.mixins = this.config.mixins || this.cache.mixins
 

--- a/src/utils/getFiles.js
+++ b/src/utils/getFiles.js
@@ -4,7 +4,6 @@ var fs = require( 'fs' )
 var glob = require( 'glob' )
 var async = require( 'async' )
 var path = require( 'path' )
-var Minimatch = require( 'minimatch' ).Minimatch
 
 /**
  * @description globs files and returns an array, used in various methods
@@ -15,12 +14,6 @@ var getFiles = function( dir ) {
 	if ( typeof dir !== 'string' ) {
 		throw new TypeError( 'getFiles err. Expected string, but received: ' + typeof dir )
 	}
-
-	this.config.exclude = ( this.config.exclude || [] ).map( function( exclude ) {
-		return new Minimatch( exclude, {
-			matchBase: true
-		} )
-	} )
 
 	glob( dir, {}, function( err, files ) {
 		if ( err ) { throw err }

--- a/src/utils/setConfig.js
+++ b/src/utils/setConfig.js
@@ -4,6 +4,7 @@ var fs = require( 'fs' )
 var path = require( 'path' )
 var pathIsAbsolute = require( 'path-is-absolute' )
 var stripJsonComments = require( 'strip-json-comments' )
+var Minimatch = require( 'minimatch' ).Minimatch
 
 // @TODO i just this sloppy just to fix some stuff
 // comes back and refactor / cleanup
@@ -103,6 +104,15 @@ var setConfig = function( configpath ) {
 			throw err
 		}
 	}
+
+	returnConfig.exclude = ( returnConfig.exclude || [] ).map( function( exclude ) {
+		return new Minimatch( exclude, {
+			matchBase: true
+		} )
+	} )
+
+	// make sure indentPref is set no matter what
+	returnConfig.indentPref = returnConfig.indentPref || false
 
 	// 4, just return the initial config if nothing found
 	return returnConfig


### PR DESCRIPTION
To make sure everything is set in one place. Also one `setConfig()` call won't mess with async operations #264 by wiping out few properties from `this.config`. Should be more testable if all config sets are in one unit. 