### PR TITLE
fix 'namingConvention', use splitAndStrip helper

### DIFF
--- a/src/checks/namingConvention.js
+++ b/src/checks/namingConvention.js
@@ -15,7 +15,7 @@ var camelRe = /^[$#.{:]+([a-zA-Z]|[${}])+([a-z]|[${}])+(([.A-Z0-9])+[a-z ]+)+\b/
  * @returns {boolean} true if convention wrong, false if not
  */
 var namingConvention = function( line ) {
-	var arr = line.split( ' ' )
+	var arr = this.splitAndStrip( ' ', line )
 	var doWeTestRe = /^[${:]+/m // determine if line should be tested at all
 	var badConvention = false
 


### PR DESCRIPTION
so whitespace is ignored and variables inside blocks are also checked