### PR TITLE
check missing space/parenthesis variations for parenSpace

### DIFF
--- a/src/checks/parenSpace.js
+++ b/src/checks/parenSpace.js
@@ -1,7 +1,8 @@
 'use strict'
 
 var parensRe = /\(.+\)/
-var parensWithSpaceRe = /\(\s+|\s\)+/
+var parensBeginWithSpaceRe = /\(\s+/
+var parensEndWithSpaceRe = /\s+\)+/
 
 
 /**
@@ -12,21 +13,17 @@ var parensWithSpaceRe = /\(\s+|\s\)+/
 var parenSpace = function( line ) {
 	if ( !parensRe.test( line ) ) { return }
 
-	var hasSpaces = false
+	var hasStartSpace = parensBeginWithSpaceRe.test( line )
+	var hasEndSpace = parensEndWithSpaceRe.test( line )
 
-	// if mixin exists and it has params
-	if ( parensWithSpaceRe.test( line ) ) {
-		hasSpaces = true
-	}
-
-	if ( this.state.conf === 'always' && hasSpaces === false ) {
+	if ( this.state.conf === 'always' && !( hasStartSpace && hasEndSpace ) ) {
 		this.msg( '( param1, param2 ) is preferred over (param1, param2)' )
 	}
-	else if ( this.state.conf === 'never' && hasSpaces === true ) {
+	else if ( this.state.conf === 'never' && ( hasStartSpace || hasEndSpace ) ) {
 		this.msg( '(param1, param2) is preferred over ( param1, param2 )' )
 	}
 
-	return hasSpaces
+	return hasStartSpace && hasEndSpace
 }
 
 module.exports = parenSpace

--- a/test/test.js
+++ b/test/test.js
@@ -1673,6 +1673,8 @@ describe( 'Linter Style Checks: ', function() {
 
 		it( 'false if no extra space', function() {
 			assert.equal( false, parenTest( 'myMixin(param1, param2)' ) )
+			assert.equal( false, parenTest( 'myMixin( param1, param2)' ) )
+			assert.equal( false, parenTest( 'myMixin(param1, param2 )' ) )
 		} )
 
 		it( 'true if has extra spaces', function() {
@@ -1693,6 +1695,8 @@ describe( 'Linter Style Checks: ', function() {
 
 		it( 'false if no extra space', function() {
 			assert.equal( false, parenTest( 'myMixin(param1, param2)' ) )
+			assert.equal( false, parenTest( 'myMixin( param1, param2)' ) )
+			assert.equal( false, parenTest( 'myMixin(param1, param2 )' ) )
 		} )
 
 		it( 'true if has extra spaces', function() {


### PR DESCRIPTION
only `myMixin(param1, param2)` and `myMixin( param1, param2 )` were recognized
handle single space `myMixin( param1, param2)` and `myMixin(param1, param2 )` too