### PR TITLE
simplify linoNo increment

### DIFF
--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -28,11 +28,9 @@ var parse = function( err, res ) {
 
 		// updating cache as we go, and passing to the next step
 		lines.forEach( function( line, lineNo ) {
-			// line nos don't start at 0
-			lineNo++
 			this.cache.origLine = line
 			this.cache.line = this.trimLine( line )
-			this.cache.lineNo = lineNo++
+			this.cache.lineNo = lineNo + 1 // line nos don't start at 0
 			this.cache.rule = ''
 			return this.setState( line )
 		}.bind( this ) )


### PR DESCRIPTION
I had a problem with double increment until I realized the second one is just ignored.
There are three solutions to simplify the code:

1. remove second post-increment: `this.cache.lineNo = lineNo`
2. remove the first one, and use pre-increment `this.cache.lineNo = ++lineNo`
3. make it so obvious that no one ever wonders why `this.cache.lineNo = lineNo + 1`

I like the last one best.
