### PR TITLE
fix duplicates without globalDupe

### DIFF
--- a/src/checks/duplicates.js
+++ b/src/checks/duplicates.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var ignoreRe = /^{|[,}]|(:after|:active|:before|@import|@require|@extend|@media|:hover|@font-face|src)|,$/
+var lastFile = ''
 
 
 /**
@@ -16,8 +17,9 @@ var duplicates = function( line ) {
 
 	// if root check not global, obliterate cache on each new file
 	if ( !this.config.globalDupe &&
-		this.cache.prevFile !== this.cache.file ) {
+		lastFile !== this.cache.file ) {
 		this.cache.sCache = {}
+		lastFile = this.cache.file
 	}
 
 	// if cache for curr context doesn't exist yet (or was obliterated), make one


### PR DESCRIPTION
Cache file change within duplicates check module so we can recognize when file changes

Current tests where `this.cache.prevFile` equals `this.cache.file` never happen. This simple `lastFile` check works fine keeping all the logic within duplicates module.