### PR TITLE
Fix quote pref check

### DIFF
--- a/src/checks/quotePref.js
+++ b/src/checks/quotePref.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var stringRe = /(?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*')/g
+
 
 /**
  * @description check that quote style is consistent with config
@@ -11,11 +13,12 @@ var quotePref = function( line ) {
 		return
 	}
 
+	stringRe.lastIndex = 0
+
 	var badQuotes = false
 	var match
-	var reg = /(?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*')/g
 
-	while ( ( match = reg.exec( line ) ) !== null ) {
+	while ( ( match = stringRe.exec( line ) ) !== null ) {
 		// if '' quotes preferred and match starts with double "" quote
 		if ( this.state.conf === 'single' && match[0].indexOf( '"' ) === 0 ) {
 			badQuotes = true

--- a/src/checks/quotePref.js
+++ b/src/checks/quotePref.js
@@ -12,36 +12,20 @@ var quotePref = function( line ) {
 	}
 
 	var badQuotes = false
+	var match
+	var reg = /(?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*')/g
 
-	// if '' quotes preferred and "" quotes are on the line
-	if ( this.state.conf === 'single' && line.indexOf( '"' ) !== -1 ) {
-		// "" are still allowed if used inside '', so we have to check that
-		if ( line.match( /('.*')+/ ) ) { // cant do [1] on something thats undefined
-			if ( !line.match( /('.*')+/ )[1].match( /(".*")+/ ) ) {
-				// if "" is on the line but isn't inside '', we got bad quotes
-				badQuotes = true
-			}
-		}
-		else {
+	while ( ( match = reg.exec( line ) ) !== null ) {
+		// if '' quotes preferred and match starts with double "" quote
+		if ( this.state.conf === 'single' && match[0].indexOf( '"' ) === 0 ) {
 			badQuotes = true
+			this.msg( 'preferred quote style is ' + this.state.conf + ' quotes' )
 		}
-	}
-	// if "" quotes preferred and '' quotes are on the line
-	else if ( this.state.conf === 'double' && line.indexOf( "'" ) !== -1 ) {
-		// '' are still allowed if used inside "", so we have to check that
-		if ( line.match( /(".*")+/ ) ) { // cant do [1] on something thats undefined
-			if ( !line.match( /(".*")+/ )[1].match( /('.*')+/ ) ) {
-				// if "" is on the line but isn't inside '', we got bad quotes
-				badQuotes = true
-			}
-		}
-		else {
+		// if "" quotes preferred and match start with single '' quote
+		else if ( this.state.conf === 'double' && match[0].indexOf( "'" ) === 0 ) {
 			badQuotes = true
+			this.msg( 'preferred quote style is ' + this.state.conf + ' quotes' )
 		}
-	}
-
-	if ( badQuotes === true ) {
-		this.msg( 'preferred quote style is ' + this.state.conf + ' quotes' )
 	}
 
 	return badQuotes

--- a/test/test.js
+++ b/test/test.js
@@ -1826,7 +1826,7 @@ describe( 'Linter Style Checks: ', function() {
 			app.state.conf = 'double'
 			assert.equal( false, quoteTest( '$var = "test string" ' ) )
 			assert.equal( false, quoteTest( '$var = "test \'substring\' string"' ) )
-			assert.equal( false, quoteTest( '$var = "test substring\'s"' ) )
+			assert.equal( false, quoteTest( '$var = "test let\'s string"' ) )
 			assert.equal( false, quoteTest( '.show-content( $content = "Hello!" )' ) )
 			assert.equal( false, quoteTest( '.show-content( $content = "Hello!" ) {' ) )
 			assert.equal( false, quoteTest( '.join-strings( $content1 = "Hello!", $content2 = "World!" )' ) )
@@ -1839,7 +1839,7 @@ describe( 'Linter Style Checks: ', function() {
 			app.state.conf = 'single'
 			assert.ok( quoteTest( '$var = "test string" ' ) )
 			assert.ok( quoteTest( '$var = "test \'substring\' string"' ) )
-			assert.ok( quoteTest( '$var = "test \'substring string"' ) )
+			assert.ok( quoteTest( '$var = "test let\'s string"' ) )
 			assert.ok( quoteTest( '.show-content( $content = "Hello!" )' ) )
 			assert.ok( quoteTest( '.join-strings( $content1 = "Hello!", $content2 = \'World!\' )' ) )
 			assert.ok( quoteTest( '.show-content( $content = "Hello!" ) {' ) )

--- a/test/test.js
+++ b/test/test.js
@@ -1816,6 +1816,7 @@ describe( 'Linter Style Checks: ', function() {
 			assert.equal( false, quoteTest( "$var = 'test \"substring\" string' " ) )
 			assert.equal( false, quoteTest( ".show-content( $content = 'Hello!' )" ) )
 			assert.equal( false, quoteTest( ".show-content( $content = 'Hello!' ) {" ) )
+			assert.equal( false, quoteTest( '.join-strings( $content1 = \'Hello!\', $content2 = \'World!\' )' ) )
 			assert.equal( false, quoteTest( "[class*='--button']" ) )
 			assert.equal( false, quoteTest( "[class*='--button'] {" ) )
 			assert.equal( false, quoteTest( "show-content( $content = 'Hello!' ) {" ) )
@@ -1825,8 +1826,10 @@ describe( 'Linter Style Checks: ', function() {
 			app.state.conf = 'double'
 			assert.equal( false, quoteTest( '$var = "test string" ' ) )
 			assert.equal( false, quoteTest( '$var = "test \'substring\' string"' ) )
+			assert.equal( false, quoteTest( '$var = "test substring\'s"' ) )
 			assert.equal( false, quoteTest( '.show-content( $content = "Hello!" )' ) )
 			assert.equal( false, quoteTest( '.show-content( $content = "Hello!" ) {' ) )
+			assert.equal( false, quoteTest( '.join-strings( $content1 = "Hello!", $content2 = "World!" )' ) )
 			assert.equal( false, quoteTest( '[class*="--button"]' ) )
 			assert.equal( false, quoteTest( '[class*="--button"] {' ) )
 			assert.equal( false, quoteTest( 'show-content( $content = "Hello!" ) {' ) )
@@ -1836,7 +1839,9 @@ describe( 'Linter Style Checks: ', function() {
 			app.state.conf = 'single'
 			assert.ok( quoteTest( '$var = "test string" ' ) )
 			assert.ok( quoteTest( '$var = "test \'substring\' string"' ) )
+			assert.ok( quoteTest( '$var = "test \'substring string"' ) )
 			assert.ok( quoteTest( '.show-content( $content = "Hello!" )' ) )
+			assert.ok( quoteTest( '.join-strings( $content1 = "Hello!", $content2 = \'World!\' )' ) )
 			assert.ok( quoteTest( '.show-content( $content = "Hello!" ) {' ) )
 			assert.ok( quoteTest( '[class*="--button"]' ) )
 		} )
@@ -1845,8 +1850,10 @@ describe( 'Linter Style Checks: ', function() {
 			app.state.conf = 'double'
 			assert.ok( quoteTest( "$var = 'test string' " ) )
 			assert.ok( quoteTest( "$var = 'test \"substring\" string' " ) )
+			assert.ok( quoteTest( "$var = 'test \"substring string' " ) )
 			assert.ok( quoteTest( ".show-content( $content = 'Hello!' )" ) )
 			assert.ok( quoteTest( ".show-content( $content = 'Hello!' ) {" ) )
+			assert.ok( quoteTest( '.join-strings( $content1 = "Hello!", $content2 = \'World!\' )' ) )
 			assert.ok( quoteTest( "[class*='--button']" ) )
 		} )
 


### PR DESCRIPTION
Additional tests and refactor for:
single quote within string: "let’s"
mixed strings: '.join-strings( $content1 = "Hello!", $content2 = \'World!\' )