### PR TITLE
Adding a check for standalone pseudo selectors.

### DIFF
--- a/src/checks/valid.js
+++ b/src/checks/valid.js
@@ -64,6 +64,14 @@ module.exports = function valid( line ) {
 		}.bind( this ) )
 	}
 
+	// if no match yet, try pseudo as standalone
+	if ( !isValid ) {
+		isValid = validJSON.pseudo.some( function( pseudo ) {
+			// psuedo selectors could have one of two colons
+			return ':' + arr[0] === pseudo || '::' + arr[0] === pseudo
+		} )
+	}
+
 	// if no match yet, try declared mixins
 	if ( !isValid ) {
 		isValid = this.cache.mixins.some( function( mixin ) {

--- a/test/test.js
+++ b/test/test.js
@@ -2266,6 +2266,19 @@ describe( 'Linter Style Checks: ', function() {
 			assert.equal( undefined, validTest( 'from 0%' ) )
 			assert.equal( undefined, validTest( 'to 100%' ) )
 		} )
+
+		it( 'true if pseudo is standalone and valid', function() {
+			assert.ok( validTest( '::-webkit-resizer' ) )
+			assert.ok( validTest( '::-webkit-scrollbar' ) )
+			assert.ok( validTest( '::-moz-inner-focus' ) )
+			assert.ok( validTest( ':focus' ) )
+			assert.ok( validTest( '::placeholder' ) )
+		} )
+
+		it( 'false if pseudo is standalone and not valid', function() {
+			assert.equal( false, validTest( '::-any-thing' ) )
+			assert.equal( false, validTest( ':focush' ) )
+		} )
 	} )
 
 	describe( 'zero units: prefer no unit values', function() {


### PR DESCRIPTION
Added one more checking section to check standalone pseudo selectors (e.g. `:focus`, `:: -webkit-scrollbar `).

Fixes #231 