### PR TITLE
check that user-home string is actually available

### DIFF
--- a/src/utils/setConfig.js
+++ b/src/utils/setConfig.js
@@ -83,9 +83,11 @@ var setConfig = function( configpath ) {
 
 			if ( !returnConfig ) {
 				// if nothing found in project, we look at the users home directory
-				files = fs.readdirSync( userHome )
-				if ( files.indexOf( '.stylintrc' ) !== -1 ) {
-					returnConfig = _parseConfig( userHome + '/.stylintrc' )
+				if ( userHome ) {
+					files = fs.readdirSync( userHome )
+					if ( files.indexOf( '.stylintrc' ) !== -1 ) {
+						returnConfig = _parseConfig( userHome + '/.stylintrc' )
+					}
 				}
 			}
 


### PR DESCRIPTION
Ran into an issue with our tests in a tox environment under node 0.12 where `require( 'user-home' )` was returning `null`, and we didn't have a default `.stylintrc` file defined, causing this code to fail.