### PR TITLE
Return minimatch instance from excludes

### DIFF
--- a/src/utils/setConfig.js
+++ b/src/utils/setConfig.js
@@ -105,7 +105,7 @@ var setConfig = function( configpath ) {
 	returnConfig.exclude = ( returnConfig.exclude || [] ).map( function( exclude ) {
 		return new Glob( exclude, {
 			matchBase: true
-		} )
+		} ).minimatch
 	} )
 
 	// make sure indentPref is set no matter what


### PR DESCRIPTION
Fixes #296 

Creds to @wojciechczerniak for this, seeing that globa actually wraps minimatch, instead of always delegating to it.
My bad for not checking better!

This does expose a hole in the tests though, there ar noe tests for the exclude, and `getFiles` is mocked out in it's tests. Should probably set up som basic mock-fs based tests or something, and add them.

//cc @rossPatton 