### PR TITLE
Add method for banning functions.

### DIFF
--- a/.stylintrc
+++ b/.stylintrc
@@ -2,7 +2,7 @@
   // testing stylintrc, real default is in core/
   "blocks": false,
   "brackets": false,
-  "bannedFunctions": ["translate3d"],
+  "bannedFunctions": [],
   "colons": "always",
   "colors": {
     "expect": "always"

--- a/.stylintrc
+++ b/.stylintrc
@@ -2,6 +2,7 @@
   // testing stylintrc, real default is in core/
   "blocks": false,
   "brackets": false,
+  "bannedFunctions": ["translate3d"],
   "colons": "always",
   "colors": {
     "expect": "always"

--- a/src/checks/banFunctions.js
+++ b/src/checks/banFunctions.js
@@ -1,0 +1,25 @@
+'use strict'
+
+
+/**
+ * @description disallows use of a specific list of key words
+ * @param {string} [line] curr line being linted
+ * @return {boolean} true if translate3d is used, false if not
+ */
+var banFunctions = function( line ) {
+	var found = false
+	var bannedFunctions = this.config['bannedFunctions'] || []
+	var index = -1
+
+	bannedFunctions.forEach( function( func ) {
+		index = line.indexOf( func )
+		if ( index !== -1 ) {
+			found = true
+			this.msg( func + ' is currently banned', index )
+		}
+	}.bind( this ) )
+
+	return found
+}
+
+module.exports = banFunctions

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -3,6 +3,7 @@ var stampit = require( 'stampit' )
 // group together all the checks in this folder
 var linterMethods = stampit().methods( {
 	lintMethods: {
+		banFunctions: require( './banFunctions' ),
 		blocks: require( './blocks' ),
 		brackets: require( './brackets' ),
 		colons: require( './colons' ),

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -37,7 +37,7 @@ var config = {
 		truncate: true
 	},
 	// rules to throw warnings on
-	bannedFunctions: ['translate3d'],
+	bannedFunctions: [],
 	// how many spaces should we prefer when indenting, pass in false if hard tabs
 	indentPref: false,
 	// enforce or disallow leading zeroes

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -36,6 +36,8 @@ var config = {
 		showHeaders: false,
 		truncate: true
 	},
+	// rules to throw warnings on
+	bannedFunctions: ['translate3d'],
 	// how many spaces should we prefer when indenting, pass in false if hard tabs
 	indentPref: false,
 	// enforce or disallow leading zeroes

--- a/test/test.js
+++ b/test/test.js
@@ -1586,6 +1586,28 @@ describe( 'Linter Style Checks: ', function() {
 		} )
 	} )
 
+	describe( 'banFunctions: ban use of specific key words', function() {
+		var banFunctions = lint.banFunctions.bind( app )
+
+		before( function() {
+			app.state.conf = true
+		} )
+
+		it( 'false if a line doesnt have any banned functions', function() {
+			assert.equal( false, banFunctions( '.foo' ) )
+		} )
+
+		it( 'false if a line has banned functions but is not found', function() {
+			app.config.bannedFunctions = ['translate3d']
+			assert.equal( false, banFunctions( '.foo' ) )
+		} )
+
+		it( 'true if line has a banned function', function() {
+			app.config.bannedFunctions = ['translate3d']
+			assert.ok( banFunctions( 'translate3d(1px, 1px, 0px)' ) )
+		} )
+	} )
+
 	describe( 'none: prefer 0 over none', function() {
 		var noneTest = lint.none.bind( app )
 


### PR DESCRIPTION
This is a small request to add new functionality to the linter for banning specific key words. It allows you to specify a list of key words that will get flagged in the linter when found. The use case for this is banning the use of things like `translate3d` in your application:

`"bannedFunctions": ["translateX", "translateY", "translate3d"]`

Let me know what you think @rossPatton , this would be a huge help for what we are trying to do.