### PR TITLE
Separated trimLine content and url regexp's and made them work better

### DIFF
--- a/src/utils/trimLine.js
+++ b/src/utils/trimLine.js
@@ -1,6 +1,7 @@
 'use strict'
 
-var urlOrContentRe = /(["'].+["'])|( +|:)url\(.+\)/
+var contentRe = /(content:\s*["'])(?:.+)(["'])/
+var urlRe = /([\S ]+\:\s*url\s*\(["'])(?:.+)(["']\))/
 
 /**
  * @description separate out line comments
@@ -17,7 +18,7 @@ var trimLine = function( line ) {
 	this.cache.comment = ''
 
 	// remove urls, content strings
-	var noUrl = line.replace( urlOrContentRe, ' ' )
+	var noUrl = line.replace( contentRe, '$1$2' ).replace( urlRe, '$1$2' )
 
 	// strip line comments, if any exist after stripping urls
 	if ( noUrl.indexOf( '//' ) !== -1 ) {


### PR DESCRIPTION
Separated the original  `urlOrCOntentRe` into 2 separate regexp's and made them more specific so they don't match incorrect patterns.