### PR TITLE
Fix issue with recursive lookup

### DIFF
--- a/src/utils/setConfig.js
+++ b/src/utils/setConfig.js
@@ -68,7 +68,7 @@ var setConfig = function( configpath ) {
 		}
 
 		// only go up to user home directory, stop recursion
-		if ( userHome ) return null
+		if ( initialCwd === userHome ) return null
 
 		// next dir level
 		var nextLevel = level + 1


### PR DESCRIPTION
The way `_recurseDirectories` works is a bit buggy since it the resulting new path is 2 levels (instead of one) down compared to the previous iteration.

This is because the joined path has as root not the initial cwd but the resulting one.

This little PR addressed that.